### PR TITLE
Expose the name of a player aura

### DIFF
--- a/Tukui/Modules/Auras/Auras.lua
+++ b/Tukui/Modules/Auras/Auras.lua
@@ -102,6 +102,8 @@ function Auras:UpdateAura(index)
 	local Name, Texture, Count, DType, Duration, ExpirationTime, Caster, IsStealable, ShouldConsolidate, SpellID, CanApplyAura, IsBossDebuff = UnitAura(self:GetParent():GetAttribute("unit"), index, self.Filter)
 
 	if (Name) then
+		self.Name = Name
+		
 		if (C.Auras.ClassicTimer) then
 			self.Holder:Hide()
 		else


### PR DESCRIPTION
Hey, thanks once again for tukui, I've been using it for like 12 years as the basis for my edit, and I do very much enjoy doing so.

Would you please consider making this small change, exposing the name of a player aura? My use case is that I want to hide aura buttons by the name of the aura (and reanchor the rest afterwards), but for now I'd have to bend over backwards doing this since the name isn't (directly) exposed. Thanks!