### PR TITLE
Update Bags.lua - Fixes #61

### DIFF
--- a/Tukui/Modules/Inventory/Bags.lua
+++ b/Tukui/Modules/Inventory/Bags.lua
@@ -1405,11 +1405,11 @@ function Bags:Enable()
 
 	if C.Bags.SortToBottom then
 		SetSortBagsRightToLeft(false)
+                SetInsertItemsLeftToRight(false)
 	else
 		SetSortBagsRightToLeft(true)
+                SetInsertItemsLeftToRight(true)
 	end
-
-	SetInsertItemsLeftToRight(false)
 	
 	-- Bug with mouse click
 	GroupLootContainer:EnableMouse(false)


### PR DESCRIPTION
Fix for bag sorting to bottom toggle not working on WOTLK, probably needs testing on Retail. Fixes #61 