### PR TITLE
Support widget only nameplates (e.g. boat/zeppelin timers)

### DIFF
--- a/Tukui/Modules/UnitFrames/Core.lua
+++ b/Tukui/Modules/UnitFrames/Core.lua
@@ -920,6 +920,34 @@ function UnitFrames:Style(unit)
 	return self
 end
 
+-- Function below is based on https://github.com/trincasidra/trincaui/blob/main/unitframes/nameplate.lua
+local function NamePlateCallback(nameplate, event, unit)
+	if event == 'NAME_PLATE_UNIT_ADDED' then
+		nameplate.blizzPlate = nameplate:GetParent().UnitFrame
+		nameplate.widgetsOnly = UnitNameplateShowsWidgetsOnly(unit)
+		nameplate.widgetSet = UnitWidgetSet(unit)
+		if nameplate.widgetsOnly then
+			nameplate.Health:SetAlpha(0)
+			nameplate.Backdrop:SetAlpha(0)
+			nameplate.Shadow:SetAlpha(0)
+			nameplate.widgetContainer = nameplate.blizzPlate.WidgetContainer
+			if nameplate.widgetContainer then
+				nameplate.widgetContainer:SetScale(2.0)
+				nameplate.widgetContainer:SetParent(nameplate)
+				nameplate.widgetContainer:ClearAllPoints()
+				nameplate.widgetContainer:SetPoint('BOTTOM', nameplate, 'BOTTOM')
+			end
+		end
+	elseif event == 'NAME_PLATE_UNIT_REMOVED' then
+		if nameplate.widgetsOnly and nameplate.widgetContainer then
+			nameplate.Health:SetAlpha(1)
+			nameplate.widgetContainer:SetParent(nameplate.blizzPlate)
+			nameplate.widgetContainer:ClearAllPoints()
+			nameplate.widgetContainer:SetPoint('TOP', nameplate.blizzPlate.castBar, 'BOTTOM')
+		end
+	end
+end
+
 function UnitFrames:CreateUnits()
 	local Movers = T["Movers"]
 
@@ -1087,7 +1115,7 @@ function UnitFrames:CreateUnits()
 			[3] = C.NamePlates.AggroColor4,
 		}
 
-		oUF:SpawnNamePlates("Tukui", nil, UnitFrames.NameplatesVariables)
+		oUF:SpawnNamePlates("Tukui", NamePlateCallback, UnitFrames.NameplatesVariables)
 	end
 end
 


### PR DESCRIPTION
Only tested on Retail!

Before:
![before](https://user-images.githubusercontent.com/2847704/208892243-b274b7d0-b519-4ec3-8a2d-7963fb73dcc7.png)

After:
![after](https://user-images.githubusercontent.com/2847704/208892255-8ffd8fb2-3aba-48ba-b3b7-e7df1f5eddb7.png)

Not sure if the callback is in the correct place, but it seems to work :)