### PR TITLE
Fix for oUF aura counter

### DIFF
--- a/Tukui/Libs/oUF/elements/auras.lua
+++ b/Tukui/Libs/oUF/elements/auras.lua
@@ -229,7 +229,7 @@ local function updateIcon(element, unit, index, offset, filter, isDebuff, visibl
 			end
 			
 			if(button.icon) then button.icon:SetTexture(texture) end
-			if(count and count > 1 and button.count) then button.count:SetText(count) end
+			if(button.count) then button.count:SetText(count > 1 and count or nil) end
 
 			local size = element.size or 16
 			button:SetSize(size, size)


### PR DESCRIPTION
If count is zero it should still call `SetText()` because aura frames are re-used.