### PR TITLE
fixing oUF.isRetail variable

### DIFF
--- a/Tukui/Libs/oUF/elements/castbar.lua
+++ b/Tukui/Libs/oUF/elements/castbar.lua
@@ -391,7 +391,7 @@ local function Enable(self, unit)
 		self:RegisterEvent('UNIT_SPELLCAST_FAILED', CastFail)
 		self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTED', CastFail)
 
-		if oUF.Retail then
+		if oUF.isRetail then
 			self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', CastInterruptible)
 			self:RegisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', CastInterruptible)
 		end
@@ -444,7 +444,7 @@ local function Disable(self)
 		self:UnregisterEvent('UNIT_SPELLCAST_FAILED', CastFail)
 		self:UnregisterEvent('UNIT_SPELLCAST_INTERRUPTED', CastFail)
 
-		if oUF.Retail then
+		if oUF.isRetail then
 			self:UnregisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', CastInterruptible)
 			self:UnregisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', CastInterruptible)
 		end

--- a/Tukui/Libs/oUF/elements/health.lua
+++ b/Tukui/Libs/oUF/elements/health.lua
@@ -319,7 +319,7 @@ local function Enable(self, unit)
 			element.SetMinMaxSmoothedValue = SmoothStatusBarMixin.SetMinMaxSmoothedValue
 		end
 
-		if oUF.Retail then
+		if oUF.isRetail then
 			self:RegisterEvent('UNIT_HEALTH', Path)
 		else
 			self:RegisterEvent('UNIT_HEALTH_FREQUENT', Path)

--- a/Tukui/Libs/oUF/elements/healthprediction.lua
+++ b/Tukui/Libs/oUF/elements/healthprediction.lua
@@ -120,8 +120,8 @@ local function Update(self, event, unit)
 	local isSmoothedEvent = event == "UNIT_MAXHEALTH" or event == "UNIT_HEALTH_FREQUENT" or event == "UNIT_HEALTH"
 	local myIncomingHeal = not oUF.isRetail and GetHealAmount(guid, currentTime, myGUID) or UnitGetIncomingHeals(unit, 'player') or 0
 	local allIncomingHeal = not oUF.isRetail and GetHealAmount(guid, currentTime, nil) or UnitGetIncomingHeals(unit) or 0
-	local absorb = oUF.Retail and UnitGetTotalAbsorbs(unit) or 0
-	local healAbsorb = oUF.Retail and UnitGetTotalHealAbsorbs(unit) or 0
+	local absorb = oUF.isRetail and UnitGetTotalAbsorbs(unit) or 0
+	local healAbsorb = oUF.isRetail and UnitGetTotalHealAbsorbs(unit) or 0
 	local health, maxHealth = UnitHealth(unit), UnitHealthMax(unit)
 	local otherIncomingHeal = 0
 	local hasOverHealAbsorb = false
@@ -241,7 +241,7 @@ local function Path(self, event, ...)
 	* unit  - the unit accompanying the event
 	--]]
 
-    if not oUF.Retail and self:IsVisible() then
+    if not oUF.isRetail and self:IsVisible() then
         for i = 1, select('#', ...) do
             if self.unit and UnitGUID(self.unit) == (UnitGUID(select(i, ...)) or select(i, ...)) then
                 return (self.HealthPrediction.Override or Update) (self, event, self.unit)

--- a/Tukui/Libs/oUF/elements/powerprediction.lua
+++ b/Tukui/Libs/oUF/elements/powerprediction.lua
@@ -66,7 +66,7 @@ local function Update(self, event, unit)
 
 	local _, _, _, startTime, endTime, _, _, notInterruptible, spellID = UnitCastingInfo(unit)
 	local mainPowerType = UnitPowerType(unit)
-	local hasAltManaBar = oUF.Retail and ALT_MANA_BAR_PAIR_DISPLAY_INFO[playerClass] and ALT_MANA_BAR_PAIR_DISPLAY_INFO[playerClass][mainPowerType]
+	local hasAltManaBar = oUF.isRetail and ALT_MANA_BAR_PAIR_DISPLAY_INFO[playerClass] and ALT_MANA_BAR_PAIR_DISPLAY_INFO[playerClass][mainPowerType]
 	local mainCost, altCost = 0, 0
 
 	if(event == 'UNIT_SPELLCAST_START' and startTime ~= endTime) then

--- a/Tukui/Libs/oUF/elements/range.lua
+++ b/Tukui/Libs/oUF/elements/range.lua
@@ -58,7 +58,7 @@ local function Update(self, event)
 	local inRange, checkedRange
 	local connected = UnitIsConnected(unit)
 	if(connected) then
-		if oUF.Retail then
+		if oUF.isRetail then
 			inRange, checkedRange = UnitInRange(unit)
 		else
 			local Spell = RangeSpellID[select(2, UnitClass("player"))]

--- a/Tukui/Libs/oUF/ouf.lua
+++ b/Tukui/Libs/oUF/ouf.lua
@@ -24,10 +24,6 @@ PetBattleFrameHider:SetAllPoints()
 PetBattleFrameHider:SetFrameStrata('LOW')
 RegisterStateDriver(PetBattleFrameHider, 'visibility', '[petbattle] hide; show')
 
-oUF.Retail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
-oUF.BCC = WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC
-oUF.Classic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
-
 -- updating of "invalid" units.
 local function enableTargetUpdate(object)
 	object.onUpdateFrequency = object.onUpdateFrequency or .5

--- a/Tukui/Libs/oUF/units.lua
+++ b/Tukui/Libs/oUF/units.lua
@@ -5,7 +5,7 @@ local Private = oUF.Private
 local enableTargetUpdate = Private.enableTargetUpdate
 
 local function updateArenaPreparationElements(self, event, elementName, specID)
-	if not oUF.Retail then
+	if not oUF.isRetail then
 		return
 	end
 
@@ -181,7 +181,7 @@ function oUF:HandleUnit(object, unit)
 	elseif(unit:match('arena%d?$')) then
 		object:RegisterEvent('ARENA_OPPONENT_UPDATE', object.UpdateAllElements, true)
 
-		if oUF.Retail then
+		if oUF.isRetail then
 			object:RegisterEvent('ARENA_PREP_OPPONENT_SPECIALIZATIONS', updateArenaPreparation, true)
 			object:SetAttribute('oUF-enableArenaPrep', true)
 			-- the event handler only fires for visible frames, so we have to hook it for arena prep

--- a/Tukui/Libs/oUF_AuraTrack/oUF_AuraTrack.lua
+++ b/Tukui/Libs/oUF_AuraTrack/oUF_AuraTrack.lua
@@ -20,7 +20,7 @@ local Tracker
 		self.AuraTrack = AuraTrack
 ]]
 
-if oUF.Retail then
+if oUF.isRetail then
 	Tracker = {
 		-- Priest
 		[194384]  = {1, 1, 0.66}, -- Atonement
@@ -369,7 +369,7 @@ local UpdateIcon = function(self, unit, spellID, texture, id, expiration, durati
 	end
 
 	local PositionX = (id * AuraTrack.IconSize) - (AuraTrack.IconSize) + (AuraTrack.Spacing * id)
-	local r, g, b = unpack(Tracker[spellID])
+	local r, g, b = unpack(AuraTrack.Tracker[spellID])
 
 	if not AuraTrack.Auras[id] then
 		AuraTrack.Auras[id] = CreateFrame("Frame", nil, AuraTrack)
@@ -428,7 +428,7 @@ local UpdateBar = function(self, unit, spellID, texture, id, expiration, duratio
 		return
 	end
 
-	local r, g, b = unpack(Tracker[spellID])
+	local r, g, b = unpack(AuraTrack.Tracker[spellID])
 	local Position = (id * AuraTrack.Thickness) - AuraTrack.Thickness
 	local X = Orientation == "VERTICAL" and -Position or 0
 	local Y = Orientation == "HORIZONTAL" and -Position or 0

--- a/Tukui/Libs/oUF_RaidDebuffs/oUF_RaidDebuffs.lua
+++ b/Tukui/Libs/oUF_RaidDebuffs/oUF_RaidDebuffs.lua
@@ -81,7 +81,7 @@ do
 		},
 		['SHAMAN'] = {
 			['Magic'] = false,
-			['Curse'] = (oUF.Retail and true) or (oUF.Classic and true) or false,
+			['Curse'] = (oUF.isRetail and true) or (oUF.isClassic and true) or false,
 			['Poison'] = true,
 			['Disease'] = true,
 		},
@@ -319,7 +319,7 @@ end
 
 local function Enable(self)
 	if self.RaidDebuffs then
-		if oUF.Retail then
+		if oUF.isRetail then
 			self:RegisterEvent("PLAYER_TALENT_UPDATE", CheckSpec, true)
 			self:RegisterEvent("CHARACTER_POINTS_CHANGED", CheckSpec, true)
 		end
@@ -339,7 +339,7 @@ end
 
 local function Disable(self)
 	if self.RaidDebuffs then
-		if oUF.Retail then
+		if oUF.isRetail then
 			self:UnregisterEvent("PLAYER_TALENT_UPDATE", CheckSpec, true)
 			self:UnregisterEvent("CHARACTER_POINTS_CHANGED", CheckSpec, true)
 		end

--- a/Tukui/Libs/oUF_Retail/init.lua
+++ b/Tukui/Libs/oUF_Retail/init.lua
@@ -1,3 +1,9 @@
-local _, ns = ...
+local parent, ns = ...
+local Toc = select(4, GetBuildInfo())
 ns.oUF = {}
 ns.oUF.Private = {}
+
+ns.oUF.isRetail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
+ns.oUF.isClassic = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC
+ns.oUF.isTBC = Toc >= 20500 and Toc < 30000
+ns.oUF.isWotLK = Toc >= 30400 and Toc < 40000


### PR DESCRIPTION
Hello.

I noticed on retail that the `oUF_AuraTrack` was not working, after looking into it I found out that the spell list is being initialized empty since the `oUF.Retail` variable is returning `nil`.
I also found out other places inside the oUF folders where those variables are being used, so I made a small fix.

I tested only on Retail and since the Retail version uses the` oUF_Retail` folder, it seems these changes will work fine.