### PR TITLE
micro menu command '/tukui mm' fix

### DIFF
--- a/Tukui/Core/Commands.lua
+++ b/Tukui/Core/Commands.lua
@@ -45,30 +45,34 @@ T.SlashHandler = function(cmd)
 	elseif (arg1 == "mm") or (arg1 == "micromenu") then
 		local MicroMenu = T.Miscellaneous.MicroMenu
 
+		local Buttons = MicroMenu:ShownMicroButtons()
+
 		if MicroMenu:IsShown() then
 			MicroMenu:Hide()
 
-			UpdateMicroButtonsParent(T.Hider)
+			if (UpdateMicroButtonsParent) then
+				UpdateMicroButtonsParent(T.Hider)
+			end
 
-			for i = 1, #MICRO_BUTTONS do
-				local Button = _G[MICRO_BUTTONS[i]]
-
-				if Button.Backdrop then
+			for i = 1, #Buttons do
+				local Button = _G[Buttons[i]]
+				if Button and Button.Backdrop then
 					Button.Backdrop:Hide()
 				end
 			end
 		else
 			MicroMenu:Show()
 
-			for i = 1, #MICRO_BUTTONS do
-				local Button = _G[MICRO_BUTTONS[i]]
-
-				if Button.Backdrop then
+			for i = 1, #Buttons do
+				local Button = _G[Buttons[i]]
+				if Button and Button.Backdrop then
 					Button.Backdrop:Show()
 				end
 			end
 
-			UpdateMicroButtonsParent(T.PetHider)
+			if (UpdateMicroButtonsParent) then
+				UpdateMicroButtonsParent(T.PetHider)
+			end
 		end
 	elseif (arg1 == "ot") or (arg1 == "quests") then
 		if T.Retail then


### PR DESCRIPTION
Hello.

On **Retail** the command `/tukui mm` throws the following error:

```lua
Message: Interface/AddOns/Tukui/Core/Commands.lua:63: attempt to get length of global 'MICRO_BUTTONS' (a nil value)
Time: Sat Mar 11 10:17:41 2023
Count: 1
Stack: Interface/AddOns/Tukui/Core/Commands.lua:63: attempt to get length of global 'MICRO_BUTTONS' (a nil value)
[string "@Interface/AddOns/Tukui/Core/Commands.lua"]:63: in function `?'
[string "@Interface/FrameXML/ChatFrame.lua"]:5229: in function `ChatEdit_ParseText'
[string "@Interface/FrameXML/ChatFrame.lua"]:4893: in function `ChatEdit_SendText'
[string "@Interface/FrameXML/ChatFrame.lua"]:4929: in function `ChatEdit_OnEnterPressed'
[string "*ChatFrame.xml:127_OnEnterPressed"]:1: in function <[string "*ChatFrame.xml:127_OnEnterPressed"]:1>

Locals: cmd = "mm"
arg1 = "mm"
arg2 = nil
arg3 = nil
arg4 = nil
MicroMenu = TukuiMicroMenu {
 HideAlerts = <function> defined @Interface/AddOns/Tukui/Modules/Miscellaneous/MicroMenu.lua:23
 Shadow = Frame {
 }
 Blizzard = <function> defined @Interface/AddOns/Tukui/Modules/Miscellaneous/MicroMenu.lua:206
 AddHooks = <function> defined @Interface/AddOns/Tukui/Modules/Miscellaneous/MicroMenu.lua:27
 Backdrop = Frame {
 }
 MoverName = "Micro Menu"
 GameMenu = <function> defined @Interface/AddOns/Tukui/Modules/Miscellaneous/MicroMenu.lua:141
 Captor = TukuiMicroMenuCaptor {
 }
 Enable = <function> defined @Interface/AddOns/Tukui/Modules/Miscellaneous/MicroMenu.lua:254
 Toggle = <function> defined @Interface/AddOns/Tukui/Modules/Miscellaneous/MicroMenu.lua:237
 0 = <userdata>
 Minimalist = <function> defined @Interface/AddOns/Tukui/Modules/Miscellaneous/MicroMenu.lua:56
 ShownMicroButtons = <function> defined @Interface/AddOns/Tukui/Modules/Miscellaneous/MicroMenu.lua:33
}
(*temporary) = 1
(*temporary) = nil
(*temporary) = <function> defined =[C]:-1
(*temporary) = <function> defined @Interface/FrameXML/MainMenuBarMicroButtons.lua:288
(*temporary) = StoreMicroButton {
 0 = <userdata>
 OnEnter = <function> defined @Interface/FrameXML/MainMenuBarMicroButtons.lua:422
 FlashBorder = Texture {
 }
 QuickKeybindButtonOnShow = <function> defined @Interface/FrameXML/QuickKeybind.lua:4
 EvaluateAlertVisibility = <function> defined @Interface/FrameXML/MainMenuBarMicroButtons.lua:1193
 QuickKeybindButtonOnEnter = <function> defined @Interface/FrameXML/QuickKeybind.lua:22
 DoModeChange = <function> defined @Interface/FrameXML/QuickKeybind.lua:95
 QuickKeybindButtonOnUpdate = <function> defined @Interface/FrameXML/QuickKeybind.lua:75
 tooltipText = "Shop"
 QuickKeybindButtonOnLeave = <function> defined @Interface/FrameXML/QuickKeybind.lua:33
 FlashContent = Texture {
 }
 QuickKeybindButtonSetTooltip = <function> defined @Interface/FrameXML/QuickKeybind.lua:52
 OnLoad = <function> defined @Interface/FrameXML/MainMenuBarMicroButtons.lua:1167
 QuickKeybindHighlightTexture = Texture {
 }
 Text = FontString {
 }
 Backdrop = Frame {
 }
 OnEvent = <function> defined @Interface/FrameXML/MainMenuBarMicroButtons.lua:1180
 QuickKeybindButtonOnHide = <function> defined @Interface/FrameXML/QuickKeybind.lua:11
 UpdateMouseWheelHandler = <function> defined @Interface/FrameXML/QuickKeybind.lua:86
 layoutIndex = 11
 QuickKeybindButtonOnMouseWheel = <function> defined @Interface/FrameXML/QuickKeybind.lua:46
 QuickKeybindButtonOnClick = <function> defined @Interface/FrameXML/QuickKeybind.lua:16
}
(*temporary) = false
(*temporary) = false
(*temporary) = <function> defined @Interface/FrameXML/QuickKeybind.lua:86
(*temporary) = MainMenuMicroButton {
 0 = <userdata>
 OnEnter = <function> defined @Interface/FrameXML/MainMenuBarMicroButtons.lua:1305
 FlashBorder = Texture {
 }
 QuickKeybindButtonOnShow = <function> defined @Interface/FrameXML/QuickKeybind.lua:4
 QuickKeybindButtonOnEnter = <function> defined @Interface/FrameXML/QuickKeybind.lua:22
 DoModeChange = <function> defined @Interface/FrameXML/QuickKeybind.lua:95
 QuickKeybindButtonOnUpdate = <function> defined @Interface/FrameXML/QuickKeybind.lua:75
 Text = FontString {
 }
 tooltipText = "Game Menu"
 QuickKeybindButto
```

If you run `/run print(MICRO_BUTTONS)` in the game, it returns `nil`.

Looking into `Miscellaneous/MicroMenu.lua` I found that `MICRO_BUTTONS` is replaced by `local Buttons = T.Retail and RetailMicroButtons or MICRO_BUTTONS`, so I made a small change in `Core/Commands.lua`.

obs.: I kept the **hide/show loop** since its was already there, but `/tukui mm` command works without then.