### PR TITLE
Update MirrorTimers.lua

### DIFF
--- a/Tukui/Modules/Miscellaneous/MirrorTimers.lua
+++ b/Tukui/Modules/Miscellaneous/MirrorTimers.lua
@@ -3,37 +3,41 @@ local T, C, L = unpack((select(2, ...)))
 local Miscellaneous = T["Miscellaneous"]
 local MirrorTimers = CreateFrame("Frame")
 
-function MirrorTimers:Update()
-	for i = 1, MIRRORTIMER_NUMTIMERS, 1 do
-		local Bar = _G["MirrorTimer"..i]
-		
-		if Bar and not Bar.isSkinned then
-			local Status = Bar.StatusBar or _G[Bar:GetName().."StatusBar"]
-			local Border = Bar.Border or _G[Bar:GetName().."Border"]
-			local Text = Bar.Text or _G[Bar:GetName().."Text"]
+local MirrorTimerContainer = _G.MirrorTimerContainer
+local MirrorTimerAtlas = _G.MirrorTimerAtlas
 
-			Bar:StripTextures()
-			Bar:CreateBackdrop()
-			Bar.Backdrop:SetBackdropColor(unpack(C.General.BackdropColor))
-			Bar.Backdrop:CreateShadow()
+function MirrorTimers:SetupTimer(timer, value, maxvalue, paused, label)
+	local Bar = MirrorTimerContainer:GetAvailableTimer(timer);
+	if (not Bar) then return end
 
-			Status:ClearAllPoints()
-			Status:SetInside(Bar, 2, 2)
-			Status:SetStatusBarTexture(C.Medias.Normal)
-			Status.SetStatusBarTexture = function() return end
-				
-			Text:ClearAllPoints()
-			Text:SetPoint("CENTER", Bar)
+	-- local originaTexture = MirrorTimerAtlas[timer]
 
-			Border:SetTexture(nil)
+	Bar:StripTextures()
+	Bar:CreateBackdrop()
+	Bar.Backdrop:SetBackdropColor(unpack(C.General.BackdropColor))
+	Bar.Backdrop:CreateShadow()
 
-			Bar.isSkinned = true
-		end
+	if (Bar.StatusBar) then
+		Bar.StatusBar:ClearAllPoints()
+		Bar.StatusBar:SetInside(Bar, 2, 2)
+		Bar.StatusBar:SetStatusBarTexture(C.Medias.Normal)
+		Bar.StatusBar.SetStatusBarTexture = function() return end
 	end
+	
+	if (Bar.Text) then
+		Bar.Text:ClearAllPoints()
+		Bar.Text:SetPoint("CENTER", Bar, "CENTER", 0, 0)
+	end
+
+	if (Bar.Border) then
+		Bar.Border:SetTexture(nil)
+	end
+
+	Bar.isSkinned = true
 end
 
 function MirrorTimers:Enable()
-	hooksecurefunc("MirrorTimer_Show", MirrorTimers.Update)
+	hooksecurefunc(MirrorTimerContainer, "SetupTimer", MirrorTimers.SetupTimer)
 end
 
 Miscellaneous.MirrorTimers = MirrorTimers

--- a/Tukui/Modules/Miscellaneous/MirrorTimers.lua
+++ b/Tukui/Modules/Miscellaneous/MirrorTimers.lua
@@ -3,76 +3,69 @@ local T, C, L = unpack((select(2, ...)))
 local Miscellaneous = T["Miscellaneous"]
 local MirrorTimers = CreateFrame("Frame")
 
-if (T.Retail) then
-	local MirrorTimerContainer = _G.MirrorTimerContainer
-	local MirrorTimerAtlas = _G.MirrorTimerAtlas
+-- Retail only function here, dont see a need to put this behind T.Retail now until Tukz can come in and fix this properly without the bandaids being applied for 10.1.5
+function MirrorTimers:SetupTimer(timer)
+	local Bar = self:GetAvailableTimer(timer);
+	if not Bar then return end
 
-	function MirrorTimers:SetupTimer(timer, value, maxvalue, paused, label)
-		local Bar = self:GetAvailableTimer(timer);
-		if (not Bar) then return end
+	Bar:StripTextures()
+	Bar:CreateBackdrop()
+	Bar.Backdrop:SetBackdropColor(unpack(C.General.BackdropColor))
+	Bar.Backdrop:CreateShadow()
 
-		-- local originaTexture = MirrorTimerAtlas[timer]
-
-		Bar:StripTextures()
-		Bar:CreateBackdrop()
-		Bar.Backdrop:SetBackdropColor(unpack(C.General.BackdropColor))
-		Bar.Backdrop:CreateShadow()
-
-		if (Bar.StatusBar) then
-			Bar.StatusBar:ClearAllPoints()
-			Bar.StatusBar:SetInside(Bar, 2, 2)
-			Bar.StatusBar:SetStatusBarTexture(C.Medias.Normal)
-			Bar.StatusBar.SetStatusBarTexture = function() return end
-		end
-		
-		if (Bar.Text) then
-			Bar.Text:ClearAllPoints()
-			Bar.Text:SetPoint("CENTER", Bar, "CENTER", 0, 0)
-		end
-
-		if (Bar.Border) then
-			Bar.Border:SetTexture(nil)
-		end
-
-		Bar.isSkinned = true
+	if (Bar.StatusBar) then
+		Bar.StatusBar:ClearAllPoints()
+		Bar.StatusBar:SetInside(Bar, 2, 2)
+		Bar.StatusBar:SetStatusBarTexture(C.Medias.Normal)
+		Bar.StatusBar.SetStatusBarTexture = function() return end
 	end
 
-	function MirrorTimers:Enable()
-		hooksecurefunc(MirrorTimerContainer, "SetupTimer", self.SetupTimer)
+	if (Bar.Text) then
+		Bar.Text:ClearAllPoints()
+		Bar.Text:SetPoint("CENTER", Bar, "CENTER", 0, 0)
 	end
-else
-	function MirrorTimers:Update()
-		for i = 1, MIRRORTIMER_NUMTIMERS, 1 do
-			local Bar = _G["MirrorTimer"..i]
-			
-			if Bar and not Bar.isSkinned then
-				local Status = Bar.StatusBar or _G[Bar:GetName().."StatusBar"]
-				local Border = Bar.Border or _G[Bar:GetName().."Border"]
-				local Text = Bar.Text or _G[Bar:GetName().."Text"]
 
-				Bar:StripTextures()
-				Bar:CreateBackdrop()
-				Bar.Backdrop:SetBackdropColor(unpack(C.General.BackdropColor))
-				Bar.Backdrop:CreateShadow()
+	if (Bar.Border) then
+		Bar.Border:SetTexture(nil)
+	end
 
-				Status:ClearAllPoints()
-				Status:SetInside(Bar, 2, 2)
-				Status:SetStatusBarTexture(C.Medias.Normal)
-				Status.SetStatusBarTexture = function() return end
-					
-				Text:ClearAllPoints()
-				Text:SetPoint("CENTER", Bar)
+	Bar.isSkinned = true
+end
 
-				Border:SetTexture(nil)
+function MirrorTimers:Update()
+	for i = 1, MIRRORTIMER_NUMTIMERS, 1 do
+		local Bar = _G["MirrorTimer"..i]
 
-				Bar.isSkinned = true
-			end
+		if Bar and not Bar.isSkinned then
+			local Status = Bar.StatusBar or _G[Bar:GetName().."StatusBar"]
+			local Border = Bar.Border or _G[Bar:GetName().."Border"]
+			local Text = Bar.Text or _G[Bar:GetName().."Text"]
+
+			Bar:StripTextures()
+			Bar:CreateBackdrop()
+			Bar.Backdrop:SetBackdropColor(unpack(C.General.BackdropColor))
+			Bar.Backdrop:CreateShadow()
+
+			Status:ClearAllPoints()
+			Status:SetInside(Bar, 2, 2)
+			Status:SetStatusBarTexture(C.Medias.Normal)
+			Status.SetStatusBarTexture = function() return end
+
+			Text:ClearAllPoints()
+			Text:SetPoint("CENTER", Bar)
+
+			Border:SetTexture(nil)
+
+			Bar.isSkinned = true
 		end
-	end
-
-	function MirrorTimers:Enable()
-		hooksecurefunc("MirrorTimer_Show", self.Update)
 	end
 end
 
+function MirrorTimers:Enable()
+	if T.Retail then
+		hooksecurefunc(_G.MirrorTimerContainer, "SetupTimer", self.SetupTimer)
+	else
+		hooksecurefunc("MirrorTimer_Show", self.Update)
+	end
+end
 Miscellaneous.MirrorTimers = MirrorTimers

--- a/Tukui/Modules/Miscellaneous/MirrorTimers.lua
+++ b/Tukui/Modules/Miscellaneous/MirrorTimers.lua
@@ -3,41 +3,76 @@ local T, C, L = unpack((select(2, ...)))
 local Miscellaneous = T["Miscellaneous"]
 local MirrorTimers = CreateFrame("Frame")
 
-local MirrorTimerContainer = _G.MirrorTimerContainer
-local MirrorTimerAtlas = _G.MirrorTimerAtlas
+if (T.Retail) then
+	local MirrorTimerContainer = _G.MirrorTimerContainer
+	local MirrorTimerAtlas = _G.MirrorTimerAtlas
 
-function MirrorTimers:SetupTimer(timer, value, maxvalue, paused, label)
-	local Bar = MirrorTimerContainer:GetAvailableTimer(timer);
-	if (not Bar) then return end
+	function MirrorTimers:SetupTimer(timer, value, maxvalue, paused, label)
+		local Bar = self:GetAvailableTimer(timer);
+		if (not Bar) then return end
 
-	-- local originaTexture = MirrorTimerAtlas[timer]
+		-- local originaTexture = MirrorTimerAtlas[timer]
 
-	Bar:StripTextures()
-	Bar:CreateBackdrop()
-	Bar.Backdrop:SetBackdropColor(unpack(C.General.BackdropColor))
-	Bar.Backdrop:CreateShadow()
+		Bar:StripTextures()
+		Bar:CreateBackdrop()
+		Bar.Backdrop:SetBackdropColor(unpack(C.General.BackdropColor))
+		Bar.Backdrop:CreateShadow()
 
-	if (Bar.StatusBar) then
-		Bar.StatusBar:ClearAllPoints()
-		Bar.StatusBar:SetInside(Bar, 2, 2)
-		Bar.StatusBar:SetStatusBarTexture(C.Medias.Normal)
-		Bar.StatusBar.SetStatusBarTexture = function() return end
+		if (Bar.StatusBar) then
+			Bar.StatusBar:ClearAllPoints()
+			Bar.StatusBar:SetInside(Bar, 2, 2)
+			Bar.StatusBar:SetStatusBarTexture(C.Medias.Normal)
+			Bar.StatusBar.SetStatusBarTexture = function() return end
+		end
+		
+		if (Bar.Text) then
+			Bar.Text:ClearAllPoints()
+			Bar.Text:SetPoint("CENTER", Bar, "CENTER", 0, 0)
+		end
+
+		if (Bar.Border) then
+			Bar.Border:SetTexture(nil)
+		end
+
+		Bar.isSkinned = true
 	end
-	
-	if (Bar.Text) then
-		Bar.Text:ClearAllPoints()
-		Bar.Text:SetPoint("CENTER", Bar, "CENTER", 0, 0)
+
+	function MirrorTimers:Enable()
+		hooksecurefunc(MirrorTimerContainer, "SetupTimer", self.SetupTimer)
+	end
+else
+	function MirrorTimers:Update()
+		for i = 1, MIRRORTIMER_NUMTIMERS, 1 do
+			local Bar = _G["MirrorTimer"..i]
+			
+			if Bar and not Bar.isSkinned then
+				local Status = Bar.StatusBar or _G[Bar:GetName().."StatusBar"]
+				local Border = Bar.Border or _G[Bar:GetName().."Border"]
+				local Text = Bar.Text or _G[Bar:GetName().."Text"]
+
+				Bar:StripTextures()
+				Bar:CreateBackdrop()
+				Bar.Backdrop:SetBackdropColor(unpack(C.General.BackdropColor))
+				Bar.Backdrop:CreateShadow()
+
+				Status:ClearAllPoints()
+				Status:SetInside(Bar, 2, 2)
+				Status:SetStatusBarTexture(C.Medias.Normal)
+				Status.SetStatusBarTexture = function() return end
+					
+				Text:ClearAllPoints()
+				Text:SetPoint("CENTER", Bar)
+
+				Border:SetTexture(nil)
+
+				Bar.isSkinned = true
+			end
+		end
 	end
 
-	if (Bar.Border) then
-		Bar.Border:SetTexture(nil)
+	function MirrorTimers:Enable()
+		hooksecurefunc("MirrorTimer_Show", self.Update)
 	end
-
-	Bar.isSkinned = true
-end
-
-function MirrorTimers:Enable()
-	hooksecurefunc(MirrorTimerContainer, "SetupTimer", MirrorTimers.SetupTimer)
 end
 
 Miscellaneous.MirrorTimers = MirrorTimers


### PR DESCRIPTION
Fixing the following error, since the `MirrorTimer_Show` was removed in path 10.1.5, and replace by `MirrorTimerContainerMixin:SetupTimer(timer, value, maxvalue, paused, label)`

**obs.: I tested theses changes on Retail and Classic, and its working fine.**

![image](https://github.com/tukui-org/Tukui/assets/5891960/1699c5c4-55b9-4ca9-8d4e-8ce94d4a8587)

[Interface Source Code Reference](https://github.com/Gethe/wow-ui-source/blob/da4222fb0cb363a4c18d0ed58aead54cca182ccc/Interface/FrameXML/MirrorTimer.lua#L44)