### PR TITLE
ALT_MANA_BAR_PAIR_DISPLAY_INFO returns nil

### DIFF
--- a/Tukui/Libs/oUF_Retail/elements/additionalpower.lua
+++ b/Tukui/Libs/oUF_Retail/elements/additionalpower.lua
@@ -60,9 +60,9 @@ local oUF = ns.oUF
 local _, playerClass = UnitClass('player')
 
 -- sourced from FrameXML/AlternatePowerBar.lua
-local ADDITIONAL_POWER_BAR_NAME = _G.ADDITIONAL_POWER_BAR_NAME or 'MANA'
-local ADDITIONAL_POWER_BAR_INDEX = _G.ADDITIONAL_POWER_BAR_INDEX or 0
-local ALT_MANA_BAR_PAIR_DISPLAY_INFO = _G.ALT_MANA_BAR_PAIR_DISPLAY_INFO
+local ALT_POWER_BAR_PAIR_DISPLAY_INFO = _G.ALT_POWER_BAR_PAIR_DISPLAY_INFO
+local ADDITIONAL_POWER_BAR_NAME = 'MANA'
+local ADDITIONAL_POWER_BAR_INDEX = 0
 
 local function UpdateColor(self, event, unit, powerType)
 	if(not (unit and UnitIsUnit(unit, 'player') and powerType == ADDITIONAL_POWER_BAR_NAME)) then return end
@@ -272,7 +272,7 @@ local function Enable(self, unit)
 		self:RegisterEvent('UNIT_DISPLAYPOWER', VisibilityPath)
 
 		if(not element.displayPairs) then
-			element.displayPairs = CopyTable(ALT_MANA_BAR_PAIR_DISPLAY_INFO)
+			element.displayPairs = CopyTable(ALT_POWER_BAR_PAIR_DISPLAY_INFO)
 		end
 
 		if(element:IsObjectType('StatusBar') and not element:GetStatusBarTexture()) then

--- a/Tukui/Libs/oUF_Retail/elements/powerprediction.lua
+++ b/Tukui/Libs/oUF_Retail/elements/powerprediction.lua
@@ -44,8 +44,8 @@ local _, ns = ...
 local oUF = ns.oUF
 
 -- sourced from FrameXML/AlternatePowerBar.lua
-local ADDITIONAL_POWER_BAR_INDEX = _G.ADDITIONAL_POWER_BAR_INDEX or 0
-local ALT_MANA_BAR_PAIR_DISPLAY_INFO = _G.ALT_MANA_BAR_PAIR_DISPLAY_INFO
+local ALT_POWER_BAR_PAIR_DISPLAY_INFO = _G.ALT_POWER_BAR_PAIR_DISPLAY_INFO
+local ADDITIONAL_POWER_BAR_INDEX = 0
 
 local _, playerClass = UnitClass('player')
 
@@ -66,8 +66,8 @@ local function Update(self, event, unit)
 
 	local _, _, _, startTime, endTime, _, _, _, spellID = UnitCastingInfo(unit)
 	local mainPowerType = UnitPowerType(unit)
-	local hasAltManaBar = ALT_MANA_BAR_PAIR_DISPLAY_INFO[playerClass]
-		and ALT_MANA_BAR_PAIR_DISPLAY_INFO[playerClass][mainPowerType]
+	local hasAltManaBar = ALT_POWER_BAR_PAIR_DISPLAY_INFO[playerClass]
+		and ALT_POWER_BAR_PAIR_DISPLAY_INFO[playerClass][mainPowerType]
 	local mainCost, altCost = 0, 0
 
 	if(event == 'UNIT_SPELLCAST_START' and startTime ~= endTime) then


### PR DESCRIPTION
Lua Error

```lua
Message: Interface/SharedXML/TableUtil.lua:238: bad argument #1 to 'pairs' (table expected, got nil)
Time: Thu Jul 13 00:01:12 2023
Count: 1
Stack: Interface/SharedXML/TableUtil.lua:238: bad argument #1 to 'pairs' (table expected, got nil)
[string "=[C]"]: in function `pairs'
[string "@Interface/SharedXML/TableUtil.lua"]:238: in function `CopyTable'
[string "@Interface/AddOns/Tukui/Libs/oUF_Retail/elements/additionalpower.lua"]:275: in function `enable'
[string "@Interface/AddOns/Tukui/Libs/oUF_Retail/ouf.lua"]:101: in function `EnableElement'
[string "@Interface/AddOns/Tukui/Libs/oUF_Retail/ouf.lua"]:343: in function <Interface/AddOns/Tukui/Libs/oUF_Retail/ouf.lua:259>
[string "=(tail call)"]: ?
[string "@Interface/AddOns/Tukui/Libs/oUF_Retail/ouf.lua"]:737: in function `Spawn'
[string "@Interface/AddOns/Tukui/Modules/UnitFrames/Core.lua"]:949: in function `CreateUnits'
[string "@Interface/AddOns/Tukui/Modules/UnitFrames/Core.lua"]:1179: in function `Enable'
[string "@Interface/AddOns/Tukui/Core/Loading.lua"]:263: in function <Interface/AddOns/Tukui/Core/Loading.lua:241>

Locals: (*temporary) = nil
(*temporary) = "table expected, got nil"
 = <function> defined =[C]:-1

```

Based on original oUF repository, they fixed by replacing `ALT_MANA_BAR_PAIR_DISPLAY_INFO` with `ALT_POWER_BAR_PAIR_DISPLAY_INFO`