### PR TITLE
Updated the mirror timers with the new Blizzard interface behaviour.

### DIFF
--- a/Tukui/Core/Colors.lua
+++ b/Tukui/Core/Colors.lua
@@ -80,4 +80,11 @@ oUF.colors.happiness = {
 	[3] = {.33,.59,.33},
 }
 
+oUF.colors.mirror = {
+	EXHAUSTION = { 1.0, 0.90, 0.0 },
+	BREATH = { 0.0, 0.50, 1.0 },
+	DEATH = { 1.0, 0.70, 0.0 },
+	FEIGNDEATH = { 1.0, 0.70, 0.0 }
+}
+
 T["Colors"] = oUF.colors


### PR DESCRIPTION
Updated the mirror timers functions to work with the new mirror container from the Blizzard interface. 
Consolidated the skinning calls into a shared function. 
Minor relevant change, which you may need is the coloring of the status bar, as  it was appearing white for me on Retail (added a relevant call for consistency for classic but it is not strictly required if you do not want to manipulate the default colors).