### PR TITLE
SoD Lifebloom LibHealComm Bug

### DIFF
--- a/Tukui/Libs/LibHealComm-4.0/LibHealComm-4.0.lua
+++ b/Tukui/Libs/LibHealComm-4.0/LibHealComm-4.0.lua
@@ -78,9 +78,12 @@ local MAX_RAID_MEMBERS = MAX_RAID_MEMBERS
 local MAX_PARTY_MEMBERS = MAX_PARTY_MEMBERS
 local COMBATLOG_OBJECT_AFFILIATION_MINE = COMBATLOG_OBJECT_AFFILIATION_MINE
 
-local build = floor(select(4,GetBuildInfo())/10000)
-local isTBC = build == 2
-local isWrath = build == 3
+-- local build = floor(select(4,GetBuildInfo())/10000)
+-- local isTBC = build == 2
+-- local isWrath = build == 3
+local isClassic = (WOW_PROJECT_ID == WOW_PROJECT_CLASSIC)
+local isTBC = (WOW_PROJECT_ID == WOW_PROJECT_BURNING_CRUSADE_CLASSIC)
+local isWrath = (WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC)
 
 local spellRankTableData = {
 	[1] = { 774, 8936, 5185, 740, 635, 19750, 139, 2060, 596, 2061, 2054, 2050, 1064, 331, 8004, 136, 755, 689, 746, 33763, 32546, 37563, 48438, 61295, 51945, 50464, 47757 },
@@ -99,6 +102,11 @@ local spellRankTableData = {
 	[14] = { 49273, 48377, 48440, 48068, 45544 },
 	[15] = { 48378, 48441 },
 }
+
+-- Season of Disvocery
+if isClassic then
+	table.insert(spellRankTableData[1], 408124)
+end
 
 local SpellIDToRank = {}
 for rankIndex, spellIDTable in pairs(spellRankTableData) do
@@ -838,6 +846,10 @@ if( playerClass == "DRUID" ) then
 		local TreeofLife = GetSpellInfo(33891) or "Tree of Life"
 
 		hotData[Regrowth] = { interval = 3, ticks = 7, coeff = (isTBC or isWrath) and 0.7 or 0.5, levels = { 12, 18, 24, 30, 36, 42, 48, 54, 60, 65, 71, 77 }, averages = { 98, 175, 259, 343, 427, 546, 686, 861, 1064, 1274, 1792, 2345 }}
+		if isClassic then
+			-- Season Of Discovery Runes
+			hotData[Lifebloom] = {interval = 1, ticks = 7, coeff = 0.52, dhCoeff = 0.34335, levels = {1}, averages = {29}, bomb = {59}}
+		end
 		if isWrath then
 			hotData[Rejuvenation] = { interval = 3, levels = { 4, 10, 16, 22, 28, 34, 40, 46, 52, 58, 60, 63, 69, 75, 80 }, averages = { 40, 70, 145, 225, 305, 380, 485, 610, 760, 945, 1110, 1165, 1325, 1490, 1690 }}
 			hotData[Lifebloom] = {interval = 1, ticks = 7, coeff = 0.66626, dhCoeff = 0.517928287, levels = {64, 72, 80}, averages = {224, 287, 371}, bomb = {480, 616, 776}}


### PR DESCRIPTION
Fix for [Issue #127](https://github.com/tukui-org/Tukui/issues/127)

The druid rune `Lifeboom` from Season of Discovery throws the error below.

I've found this [post on curse forge](https://legacy.curseforge.com/wow/addons/libhealcomm-4-0/issues/95) about it.
So I implemented it, since I made a druid on SoD, and this was annoying me.

Not sure If you want to add it, since SoD can be a temporary thing. But these changes fixed for me.

```text
Message: ...ddOns/Tukui/Libs/LibHealComm-4.0/LibHealComm-4.0.lua:818: attempt to perform arithmetic on local 'requiresLevel' (a nil value)
Time: Tue Jan 16 21:42:47 2024
Count: 1
Stack: ...ddOns/Tukui/Libs/LibHealComm-4.0/LibHealComm-4.0.lua:818: attempt to perform arithmetic on local 'requiresLevel' (a nil value)
[string "@Interface/AddOns/Tukui/Libs/LibHealComm-4.0/LibHealComm-4.0.lua"]:818: in function <...ddOns/Tukui/Libs/LibHealComm-4.0/LibHealComm-4.0.lua:807>
[string "@Interface/AddOns/Tukui/Libs/LibHealComm-4.0/LibHealComm-4.0.lua"]:967: in function <...ddOns/Tukui/Libs/LibHealComm-4.0/LibHealComm-4.0.lua:965>
[string "@Interface/AddOns/Tukui/Libs/LibHealComm-4.0/LibHealComm-4.0.lua"]:2706: in function `?'
[string "@Interface/AddOns/Tukui/Libs/LibHealComm-4.0/LibHealComm-4.0.lua"]:3348: in function <...ddOns/Tukui/Libs/LibHealComm-4.0/LibHealComm-4.0.lua:3346>

Locals: spellData = <table> {
 levels = <table> {
 }
 bomb = <table> {
 }
 coeff = 0.520000
 interval = 1
 ticks = 7
 averages = <table> {
 }
 dhCoeff = 0.343350
}
spellName = "Lifebloom"
spellID = 408124
spellRank = nil
average = nil
requiresLevel = nil
(*temporary) = <function> defined =[C]:-1
(*temporary) = 18
(*temporary) = nil
(*temporary) = "attempt to perform arithmetic on local 'requiresLevel' (a nil value)"
type = <function> defined =[C]:-1
min = <function> defined =[C]:-1
playerLevel = 18
```