### PR TITLE
RaidDebuffs #192

### DIFF
--- a/Tukui/Libs/oUF_RaidDebuffs/oUF_RaidDebuffs.lua
+++ b/Tukui/Libs/oUF_RaidDebuffs/oUF_RaidDebuffs.lua
@@ -188,6 +188,20 @@ local canDispel = {
 	}
 }
 
+--[[ Event handler for PLAYER_LOGIN.
+
+* self		- oUF UnitFrame
+* event		- PLAYER_LOGIN
+]]
+local function ResetDispelList(self, event)
+	if event == "PLAYER_LOGIN" then
+		dispelList["Magic"]		= false
+		dispelList["Poison"]	= false
+		dispelList["Disease"]	= false
+		dispelList["Curse"]		= false
+	end
+end
+
 --[[ Event handler for SPELLS_CHANGED.
 
 * self		- oUF UnitFrame
@@ -438,6 +452,7 @@ local function Enable(self)
 		end
 
 		-- Update the dispelList at login and whenever spells change (talent or spec change)
+		self:RegisterEvent("PLAYER_LOGIN", ResetDispelList, true)
 		self:RegisterEvent("SPELLS_CHANGED", UpdateDispelList, true)
 		self:RegisterEvent("UNIT_AURA", Update)
 
@@ -452,6 +467,7 @@ local function Disable(self)
 
 	if element then
 		element.debuffCache = nil
+		self:UnregisterEvent("PLAYER_LOGIN", ResetDispelList, true)
 		self:UnregisterEvent("SPELLS_CHANGED", UpdateDispelList, true)
 		self:UnregisterEvent("UNIT_AURA", Update)
 	end

--- a/Tukui/Libs/oUF_RaidDebuffs/oUF_RaidDebuffs.lua
+++ b/Tukui/Libs/oUF_RaidDebuffs/oUF_RaidDebuffs.lua
@@ -321,12 +321,14 @@ local function FilterAura(self, unit, AuraData)
 	end
 end
 
---[[ Aura scan when isFullUpdate.
+--[[ Reset cache and full scan when isFullUpdate.
 
 * self				- oUF UnitFrame
 * unit				- Tracked unit
 ]]
 local function FullUpdate(self, unit)
+	table.wipe(self.element.debuffCache)
+
 	if ForEachAura then
 		-- Mainline iteration-style.
 		ForEachAura(unit, "HARMFUL", nil,
@@ -357,9 +359,9 @@ end
 ]]
 local function Update(self, event, unit, updateInfo)
 	-- Exit when unit doesn't match or no updateInfo provided or target can't be assisted
-	if event ~= "UNIT_AURA" or self.unit ~= unit or not updateInfo or not UnitCanAssist("player", unit) then return end
+	if event ~= "UNIT_AURA" or self.unit ~= unit or not UnitCanAssist("player", unit) then return end
 
-	if updateInfo.isFullUpdate then
+	if not updateInfo or updateInfo.isFullUpdate then
 		FullUpdate(self, unit)
 		return
 	end


### PR DESCRIPTION
Seems buffs are dispelable too, so added explicit filter for Debuffs. 
Already feared we won't always get events for expired auras, but of cause in my testing (not raid) that never happened. 

Cache reset in case FullUpdate is essential. Seems this doesn't happen often though. 
Reset dispellist handles the case when switching characters from dispeller to one not in the list. 