### PR TITLE
Fixes for oUF_Atonement and oUF_RaidDebuffs

### DIFF
--- a/Tukui/Libs/oUF_Atonement/oUF_Atonement.lua
+++ b/Tukui/Libs/oUF_Atonement/oUF_Atonement.lua
@@ -18,11 +18,11 @@ local Active = false
 
 --[[ Find the Atonement buffs.
 
-* self				- oUF UnitFrame
-* unit				- Tracked unit
-* AuraData			- (optional) UNIT_AURA event payload
+* self        - oUF UnitFrame
+* unit        - Tracked unit
+* AuraData    - (optional) UNIT_AURA event payload
 
-* returns			true, if no further scanning needed (found or no more data)
+* returns     true, if no further scanning needed (found or no more data)
 ]]
 local function FindAtonement(self, unit, AuraData)
 	local element = self.Atonement
@@ -53,8 +53,8 @@ end
 
 --[[ Full scan when isFullUpdate.
 
-* self				- oUF UnitFrame
-* unit				- Tracked unit
+* self    - oUF UnitFrame
+* unit    - Tracked unit
 ]]
 local function FullUpdate(self, unit)
 	if AuraUtil then
@@ -68,6 +68,26 @@ local function FullUpdate(self, unit)
 		while not FindAtonement(self, unit, GetAuraDataByIndex(unit, i, "HELPFUL|PLAYER")) do
 			i = i + 1
 		end
+	end
+end
+
+--[[ Activate element for Discipline.
+
+* self     - oUF UnitFrame
+* event    - SPELLS_CHANGED
+]]
+local function CheckSpec(self, event)
+	local element = self.Atonement
+	local SpecIndexDiscipline = 1
+
+	if GetSpecialization() == SpecIndexDiscipline then
+		Active = true
+	else
+		if element.ticker then element.ticker:Cancel() end
+		element:SetValue(0)
+		element:Hide()
+
+		Active = false
 	end
 end
 
@@ -92,22 +112,6 @@ local function Update(self, event, unit, updateInfo)
 		for _, AuraData in pairs(updateInfo.addedAuras) do
 			FindAtonement(self, unit, AuraData)
 		end
-	end
-end
-
---[[ Activate element for Discipline. ]]
-local function CheckSpec(self, event)
-	local element = self.Atonement
-	local SpecIndexDiscipline = 1
-
-	if GetSpecialization() == SpecIndexDiscipline then
-		Active = true
-	else
-		if element.ticker then element.ticker:Cancel() end
-		element:SetValue(0)
-		element:Hide()
-
-		Active = false
 	end
 end
 

--- a/Tukui/Libs/oUF_Atonement/oUF_Atonement.lua
+++ b/Tukui/Libs/oUF_Atonement/oUF_Atonement.lua
@@ -1,3 +1,33 @@
+--[[
+# Element: Atonement Indicator
+
+	Provides an indication of active Atonement buffs on units.
+
+## Widget
+
+	Atonement - A 'StatusBar' indicating the presence of an Atonement buff.
+
+## Sub-Widgets
+
+	.Backdrop - A 'Texture' used as background.
+
+## Notes
+
+	A background will be created if not provided.
+
+## Examples
+
+	-- position and size
+	local Atonement = CreateFrame("StatusBar", nil, Health)
+	Atonement:SetHeight(6)
+	Atonement:SetPoint("BOTTOMLEFT", Health, "BOTTOMLEFT")
+	Atonement:SetPoint("BOTTOMRIGHT", Health, "BOTTOMRIGHT")
+	Atonement:SetStatusBarTexture(healthTexture)
+	Atonement:SetFrameLevel(Health:GetFrameLevel() + 1)
+
+	-- Register it with oUF
+	self.Atonement = Atonement
+]]
 local _, ns = ...
 local oUF = ns.oUF or _G.oUF
 assert(oUF, "oUF_Atonement cannot find an instance of oUF. If your oUF is embedded into a layout, it may not be embedded properly.")
@@ -16,14 +46,8 @@ local ATONEMENT_PVP_ID = 214206
 
 local Active = false
 
---[[ Find the Atonement buffs.
-
-* self        - oUF UnitFrame
-* unit        - Tracked unit
-* AuraData    - (optional) UNIT_AURA event payload
-
-* returns     true, if no further scanning needed (found or no more data)
-]]
+-- Filter function to find the Atonement buffs.
+-- Returns true, if no further scanning needed (found or no more data) to shorten a full update.
 local function FindAtonement(self, unit, AuraData)
 	local element = self.Atonement
 
@@ -51,11 +75,7 @@ local function FindAtonement(self, unit, AuraData)
 	end
 end
 
---[[ Full scan when isFullUpdate.
-
-* self    - oUF UnitFrame
-* unit    - Tracked unit
-]]
+-- Full scan when isFullUpdate.
 local function FullUpdate(self, unit)
 	if AuraUtil then
 		AuraUtil.ForEachAura(unit, "HELPFUL|PLAYER", nil,
@@ -71,11 +91,7 @@ local function FullUpdate(self, unit)
 	end
 end
 
---[[ Activate element for Discipline.
-
-* self     - oUF UnitFrame
-* event    - SPELLS_CHANGED
-]]
+-- Activate element for Discipline.
 local function CheckSpec(self, event)
 	local element = self.Atonement
 	local SpecIndexDiscipline = 1

--- a/Tukui/Libs/oUF_RaidDebuffs/oUF_RaidDebuffs.lua
+++ b/Tukui/Libs/oUF_RaidDebuffs/oUF_RaidDebuffs.lua
@@ -342,16 +342,19 @@ end
 * AuraData          - UNIT_AURA event payload
 ]]
 local function FilterAura(self, unit, auraInstanceID, AuraData)
+	local debuffCache = self.RaidDebuffs.debuffCache
+
 	if AuraData then -- added aura or valid update
 		if AuraData.isHarmful then
 			local dispelName = AuraData.dispelName
+
 			if dispelName and dispelList[dispelName] then
 				cacheWrite(self, unit, auraInstanceID, priorityList[dispelName], AuraData)
 			end
 		end
-	else -- removed aura or invalid update
+	elseif debuffCache[auraInstanceID] then -- removed aura or invalid update
 		cacheWrite(self, unit, auraInstanceID, nil, nil)
-	end
+	end -- aura we dont care about
 end
 
 --[[ Reset cache and full scan when isFullUpdate.

--- a/Tukui/Libs/oUF_RaidDebuffs/oUF_RaidDebuffs.lua
+++ b/Tukui/Libs/oUF_RaidDebuffs/oUF_RaidDebuffs.lua
@@ -1,19 +1,19 @@
 --[=[
-	Shows Debuffs on Unit Frames.
+    Shows Debuffs on Unit Frames.
 
-	Sub-Widgets will be created if not provided.
+    Sub-Widgets will be created if not provided.
 
-	Member Variables
-	.font			Font details used for timer and stacks
-	.fontheight 	| used if Sub-Widgets aren't provided
-	.fontFlags		| not needed otherwise
+    Member Variables
+    .font          Font details used for timer and stacks
+    .fontheight    | used if Sub-Widgets aren't provided
+    .fontFlags     | not needed otherwise
 
-	Sub-Widgets
-	.icon			The Icon/Texture of the debuff
-	.cd 			A Cooldown frame
-	.timer			A Text showing the remaining duration
-	.count			A Text showing the number of stacks
-	.Backdrop		Backdrops border is used to indicate the debuff type
+    Sub-Widgets
+    .icon          The Icon/Texture of the debuff
+    .cd            A Cooldown frame
+    .timer         A Text showing the remaining duration
+    .count         A Text showing the number of stacks
+    .Backdrop      Backdrops border is used to indicate the debuff type
 --]=]
 local _, ns = ...
 local oUF = ns.oUF or oUF
@@ -194,8 +194,8 @@ local canDispel = {
 
 Only fires for a player frame.
 
-* self		- oUF UnitFrame
-* event		- SPELLS_CHANGED
+* self     - oUF UnitFrame
+* event    - SPELLS_CHANGED
 ]]
 local function UpdateDispelList(self, event)
 	if event == "SPELLS_CHANGED" then
@@ -206,7 +206,7 @@ end
 
 --[[ Returns a format string for timers.
 
-* time	- Time in seconds
+* time    - Time in seconds
 ]]
 local function timeFormat(time)
 	if time < 3 then
@@ -220,9 +220,9 @@ end
 
 --[[ Show the debuff element.
 
-* self				- oUF UnitFrame
-* unit				- Tracked unit
-* auraInstanceID	- auraInstanceID of the debuff to be displayed
+* self              - oUF UnitFrame
+* unit              - Tracked unit
+* auraInstanceID    - auraInstanceID of the debuff to be displayed
 ]]
 local function ShowElement(self, unit, auraInstanceID)
 	local element = self.RaidDebuffs
@@ -261,8 +261,8 @@ end
 
 --[[ Hide the debuff element.
 
-* self	- oUF UnitFrame
-* unit	- Tracked unit
+* self    - oUF UnitFrame
+* unit    - Tracked unit
 ]]
 local function HideElement(self, unit)
 	local element = self.RaidDebuffs
@@ -280,8 +280,8 @@ end
 
 --[[ Select the Debuff with highest priority to display, hide element when none left.
 
-* self	- oUF UnitFrame
-* unit	- Tracked unit
+* self    - oUF UnitFrame
+* unit    - Tracked unit
 ]]
 local function SelectPrioDebuff(self, unit)
 	local debuffCache = self.RaidDebuffs.debuffCache
@@ -307,17 +307,17 @@ end
 
 Cache writes need to call SelectPrioDebuff after update to ensure the display is also updated.
 
-	table<auraInstanceID, aura>
-	aura = {
-		.priority	- See priorityList
-		.AuraData	- See UNIT_AURA event payload
-	}
+    table<auraInstanceID, aura>
+    aura = {
+        .priority    - See priorityList
+        .AuraData    - See UNIT_AURA event payload
+    }
 
-* self				- oUF UnitFrame
-* unit				- Tracked unit				-
-* auraInstanceID	- UNIT_AURA event payload
-* priority			- See priorityList
-* AuraData			- UNIT_AURA event payload
+* self              - oUF UnitFrame
+* unit              - Tracked unit
+* auraInstanceID    - UNIT_AURA event payload
+* priority          - See priorityList
+* AuraData          - UNIT_AURA event payload
 ]]
 cacheWrite = function(self, unit, auraInstanceID, priority, AuraData)
 	local debuffCache = self.RaidDebuffs.debuffCache
@@ -336,10 +336,10 @@ end
 
 --[[ Filter for dispellable debuffs.
 
-* self				- oUF UnitFrame
-* unit				- Tracked unit
-* auraInstanceID	- UNIT_AURA event payload
-* AuraData			- UNIT_AURA event payload
+* self              - oUF UnitFrame
+* unit              - Tracked unit
+* auraInstanceID    - UNIT_AURA event payload
+* AuraData          - UNIT_AURA event payload
 ]]
 local function FilterAura(self, unit, auraInstanceID, AuraData)
 	if AuraData then -- added aura or valid update
@@ -356,8 +356,8 @@ end
 
 --[[ Reset cache and full scan when isFullUpdate.
 
-* self				- oUF UnitFrame
-* unit				- Tracked unit
+* self    - oUF UnitFrame
+* unit    - Tracked unit
 ]]
 local function FullUpdate(self, unit)
 	table.wipe(self.RaidDebuffs.debuffCache)
@@ -386,10 +386,10 @@ end
 
 --[[ Event handler for UNIT_AURA.
 
-* self			- oUF UnitFrame
-* event			- UNIT_AURA
-* unit			- Payload of event: unitTarget
-* updateInfo	- Payload of event: UnitAuraUpdateInfo
+* self          - oUF UnitFrame
+* event         - UNIT_AURA
+* unit          - Payload of event: unitTarget
+* updateInfo    - Payload of event: UnitAuraUpdateInfo
 ]]
 local function Update(self, event, unit, updateInfo)
 	-- Exit when unit doesn't match or target can't be assisted


### PR DESCRIPTION
Atonement:
Element is now always receiving updates (for Priests) but further processing is only done when "Active" is set.
Was: The CheckSpec events were only call for the player frame, so registering for updates there also only worked for the player frame. Element couldn't be used for e.g. party or raid.

RaidDebuffs:
Added a cacheWrite function to ensure the needed function for display updates is also called.
Made FilterAura function more robust. Is now able to handle (bad) updates without data.