### PR TITLE
WidgetManager ready for external edits

### DIFF
--- a/Tukui/Modules/UnitFrames/Groups/Raid.lua
+++ b/Tukui/Modules/UnitFrames/Groups/Raid.lua
@@ -47,10 +47,11 @@ end
 
 -- Configures oUF element Power.
 local function Power(unitFrame, config)
+	local health = unitFrame.Health
 	local power = CreateFrame("StatusBar", nil, unitFrame)
 	power:SetHeight(config.height or 3)
-	power:SetPoint("TOPLEFT", unitFrame.Health, "BOTTOMLEFT", 0, -1)
-	power:SetPoint("TOPRIGHT", unitFrame.Health, "BOTTOMRIGHT", 0, -1)
+	power:SetPoint("TOPLEFT", health, "BOTTOMLEFT", 0, -1)
+	power:SetPoint("TOPRIGHT", health, "BOTTOMRIGHT", 0, -1)
 	power:SetStatusBarTexture(PowerTexture)
 
 	power.Background = power:CreateTexture(nil, "BORDER")
@@ -111,8 +112,9 @@ end
 
 -- Configures oUF element Buffs (part of Auras).
 local function Buffs(unitFrame, config)
-	local buffs = CreateFrame("Frame", unitFrame:GetName().."Buffs", unitFrame.Health)
-	buffs:SetPoint(config.anchor[1], unitFrame.Health, config.anchor[2], config.anchor[3], config.anchor[4])
+	local health = unitFrame.Health
+	local buffs = CreateFrame("Frame", unitFrame:GetName().."Buffs", health)
+	buffs:SetPoint(config.anchor[1], health, config.anchor[2], config.anchor[3], config.anchor[4])
 	buffs:SetHeight(config.height)
 	buffs:SetWidth(config.width)
 
@@ -193,7 +195,8 @@ end
 -- oUF Plugins
 -- Configures oUF_AuraTrack.
 local function AuraTrack(unitFrame, config)
-	local auraTrack = CreateFrame("Frame", nil, unitFrame.Health)
+	local health = unitFrame.Health
+	local auraTrack = CreateFrame("Frame", nil, health)
 	auraTrack:SetAllPoints()
 	auraTrack.Texture = C.Medias.Normal
 	auraTrack.Font = C.Medias.Font
@@ -210,7 +213,7 @@ local function RaidDebuffs(unitFrame, config)
 	local raidDebuffs = CreateFrame("Frame", nil, health)
 
 	raidDebuffs:SetSize(config.size, config.size)
-	raidDebuffs:SetPoint(config.anchor[1], config.anchor[2], config.anchor[3], config.anchor[4])
+	raidDebuffs:SetPoint(config.anchor[1], health, config.anchor[2], config.anchor[3], config.anchor[4])
 	raidDebuffs:SetFrameLevel(health:GetFrameLevel() + 10)
 	raidDebuffs.icon = raidDebuffs:CreateTexture(nil, "ARTWORK")
 	raidDebuffs.icon:SetTexCoord(.1, .9, .1, .9)
@@ -235,15 +238,16 @@ end
 -- additional plugins
 -- Creates a panel for the unit name.
 local function NamePanel(unitFrame, config)
+	local power = unitFrame.Power
 	local panel = CreateFrame("Frame", nil, unitFrame)
-	panel:SetPoint("TOPLEFT", unitFrame.Power, "BOTTOMLEFT", 0, -1)
-	panel:SetPoint("TOPRIGHT", unitFrame.Power, "BOTTOMRIGHT", 0, -1)
+	panel:SetPoint("TOPLEFT", power, "BOTTOMLEFT", 0, -1)
+	panel:SetPoint("TOPRIGHT", power, "BOTTOMRIGHT", 0, -1)
 	panel:SetPoint("BOTTOM", 0, 0)
 	panel:CreateBackdrop()
 	panel.Backdrop:SetBorderColor(0, 0, 0, 0)
 
 	local name = panel:CreateFontString(nil, "OVERLAY")
-	name:SetPoint(config.nameAnchor)
+	name:SetPoint(config.nameAnchor[1], panel, config.nameAnchor[2], config.nameAnchor[3], config.nameAnchor[4])
 	name:SetFontObject(Font)
 
 	unitFrame.Panel = panel

--- a/Tukui/Modules/UnitFrames/Groups/Raid.lua
+++ b/Tukui/Modules/UnitFrames/Groups/Raid.lua
@@ -8,8 +8,7 @@ local PowerTexture
 local Font
 local HealthFont
 
--- Make raid widgets available for external edits.
-local RaidWidgets = UnitFrames.WidgetManager
+
 
 -- oUF base elements
 -- Configures oUF element Health.
@@ -280,6 +279,8 @@ local function createHighlight(unitFrame)
 	unitFrame.Highlight = Highlight
 end
 
+-- Create new WidgetManager for Raid
+local RaidWidgets = UnitFrames.WidgetManager.new()
 
 --[[ Raid style function. ]]
 function UnitFrames.Raid(self)

--- a/Tukui/Modules/UnitFrames/Groups/Raid.lua
+++ b/Tukui/Modules/UnitFrames/Groups/Raid.lua
@@ -290,35 +290,33 @@ function UnitFrames.Raid(self)
 	self.Backdrop:SetBackdrop(UnitFrames.Backdrop)
 	self.Backdrop:SetBackdropColor(0, 0, 0)
 
-	-- oUF base elements
 	RaidWidgets:add("Health", createHealth, { height = C.Raid.HeightSize - 1 - 3 - 1 -18,  -- border, power, border, namepanel
 		valueFont = HealthFont, valueAnchor = {"CENTER", 0, -6}, Tag = C.Raid.HealthTag.Value })
 	RaidWidgets:add("Power", createPower, {})
+	RaidWidgets:add("NamePanel", createNamePanel, { nameAnchor = "CENTER" })
+
 	RaidWidgets:add("RaidTargetIndicator", createRaidTargetIndicator, { size = C.UnitFrames.RaidIconSize, anchor = {"TOP", 0, C.UnitFrames.RaidIconSize / 2} })
 	RaidWidgets:add("ReadyCheckIndicator", createReadyCheckIndicator, { size = 12, anchor = {"CENTER"} })
 	RaidWidgets:add("ResurrectIndicator", createResurrectIndicator, { size = 24, anchor = {"CENTER"} })
 	RaidWidgets:add("Range", createRange, { outsideAlpha = C["Raid"].RangeAlpha })
-	if C.Raid.RaidBuffsStyle.Value == "Standard" then
-		RaidWidgets:add("Buffs", createBuffs, { filter = C.Raid.RaidBuffs.Value == "All" and "HELPFUL" or "HELPFUL|RAID",
-			onlyShowPlayer = C.Raid.RaidBuffs.Value == "Self", height = 16, width = 79, anchor = {"TOPLEFT"},
-			buffSize = 16, buffNum = 5 })
-	end
+	RaidWidgets:add("Highlight", createHighlight, { size = C.Raid.HighlightSize, color = C.Raid.HighlightColor })
+
 	if C.UnitFrames.HealComm then
 		RaidWidgets:add("HealComm", createHealComm, { width = C.Raid.WidthSize })
 	end
 
-	-- oUF plugins
-	if C.Raid.RaidBuffsStyle.Value == "Aura Track" then
+	if C.Raid.RaidBuffsStyle.Value == "Standard" then
+		RaidWidgets:add("Buffs", createBuffs, { filter = C.Raid.RaidBuffs.Value == "All" and "HELPFUL" or "HELPFUL|RAID",
+			onlyShowPlayer = C.Raid.RaidBuffs.Value == "Self", height = 16, width = 79, anchor = {"TOPLEFT"},
+			buffSize = 16, buffNum = 5 })
+	elseif C.Raid.RaidBuffsStyle.Value == "Aura Track" then
 		RaidWidgets:add("AuraTrack", createAuraTrack, { icons = C.Raid.AuraTrackIcons, texture = C.Raid.AuraTrackSpellTextures, thickness = C.Raid.AuraTrackThickness })
 	end
+
 	if C.Raid.DebuffWatch then
 		local height = C.Raid.HeightSize - 1 - 3 - 1 -18  -- border, power, border, namepanel
 		RaidWidgets:add("RaidDebuffs", createRaidDebuffs, { size = height >= 32 and height - 16 or height, anchor = {"CENTER"} })
 	end
-
-	-- additional plugins
-	RaidWidgets:add("NamePanel", createNamePanel, { nameAnchor = "CENTER" })
-	RaidWidgets:add("Highlight", createHighlight, { size = C.Raid.HighlightSize, color = C.Raid.HighlightColor })
 
 	RaidWidgets:createWidgets(self)
 

--- a/Tukui/Modules/UnitFrames/Groups/Raid.lua
+++ b/Tukui/Modules/UnitFrames/Groups/Raid.lua
@@ -12,161 +12,162 @@ local HealthFont
 
 -- oUF base elements
 -- Configures oUF element Health.
-local function createHealth(unitFrame, config)
-	local Health = CreateFrame("StatusBar", nil, unitFrame)
-	Health:SetPoint("TOPLEFT")
-	Health:SetPoint("TOPRIGHT")
-	Health:SetHeight(config.height)
-	Health:SetStatusBarTexture(HealthTexture)
+local function Health(unitFrame, config)
+	local health = CreateFrame("StatusBar", nil, unitFrame)
+	health:SetPoint("TOPLEFT")
+	health:SetPoint("TOPRIGHT")
+	health:SetHeight(config.height)
+	health:SetStatusBarTexture(HealthTexture)
 
 	if C.Raid.VerticalHealth then
-		Health:SetOrientation("VERTICAL")
+		health:SetOrientation("VERTICAL")
 	end
 
-	Health.Background = Health:CreateTexture(nil, "BACKGROUND")
-	Health.Background:SetTexture(HealthTexture)
-	Health.Background:SetAllPoints(Health)
-	Health.Background.multiplier = C.UnitFrames.StatusBarBackgroundMultiplier / 100
+	health.Background = health:CreateTexture(nil, "BACKGROUND")
+	health.Background:SetTexture(HealthTexture)
+	health.Background:SetAllPoints(health)
+	health.Background.multiplier = C.UnitFrames.StatusBarBackgroundMultiplier / 100
 
-	Health.Value = Health:CreateFontString(nil, "OVERLAY")
-	Health.Value:SetFontObject(config.valueFont)
-	Health.Value:SetPoint(config.valueAnchor[1], Health, config.valueAnchor[2], config.valueAnchor[3], config.valueAnchor[4])
+	health.Value = health:CreateFontString(nil, "OVERLAY")
+	health.Value:SetFontObject(config.valueFont)
+	health.Value:SetPoint(config.valueAnchor[1], health, config.valueAnchor[2], config.valueAnchor[3], config.valueAnchor[4])
 
-	Health.colorDisconnected = true
-	Health.colorClass = true
-	Health.colorReaction = true
+	health.colorDisconnected = true
+	health.colorClass = true
+	health.colorReaction = true
+
 	if C.UnitFrames.Smoothing then
-		Health.smoothing = true
+		health.smoothing = true
 	end
 
-	unitFrame.Health = Health
-	unitFrame.Health.bg = Health.Background
-	unitFrame:Tag(Health.Value, config.Tag)
+	unitFrame.Health = health
+	unitFrame.Health.bg = health.Background
+	unitFrame:Tag(health.Value, config.Tag)
 end
 
 -- Configures oUF element Power.
-local function createPower(unitFrame, config)
-	local Power = CreateFrame("StatusBar", nil, unitFrame)
-	Power:SetHeight(config.height or 3)
-	Power:SetPoint("TOPLEFT", unitFrame.Health, "BOTTOMLEFT", 0, -1)
-	Power:SetPoint("TOPRIGHT", unitFrame.Health, "BOTTOMRIGHT", 0, -1)
+local function Power(unitFrame, config)
+	local power = CreateFrame("StatusBar", nil, unitFrame)
+	power:SetHeight(config.height or 3)
+	power:SetPoint("TOPLEFT", unitFrame.Health, "BOTTOMLEFT", 0, -1)
+	power:SetPoint("TOPRIGHT", unitFrame.Health, "BOTTOMRIGHT", 0, -1)
+	power:SetStatusBarTexture(PowerTexture)
 
-	Power.Background = Power:CreateTexture(nil, "BORDER")
-	Power.Background:SetTexture(PowerTexture)
-	Power.Background:SetAllPoints(Power)
-	Power.Background.multiplier = C.UnitFrames.StatusBarBackgroundMultiplier / 100
+	power.Background = power:CreateTexture(nil, "BORDER")
+	power.Background:SetTexture(PowerTexture)
+	power.Background:SetAllPoints(power)
+	power.Background.multiplier = C.UnitFrames.StatusBarBackgroundMultiplier / 100
 
-	Power:SetStatusBarTexture(PowerTexture)
+	power.colorPower = true
 
-	Power.colorPower = true
 	if C.UnitFrames.Smoothing then
-		Power.smoothing = true
+		power.smoothing = true
 	end
 
-	unitFrame.Power = Power
-	unitFrame.Power.bg = Power.Background
+	unitFrame.Power = power
+	unitFrame.Power.bg = power.Background
 end
 
 -- Configures oUF element RaidTargetIndicator.
-local function createRaidTargetIndicator(unitFrame, config)
-	local Health = unitFrame.Health
-	local RaidIcon = Health:CreateTexture(nil, "OVERLAY")
-	RaidIcon:SetSize(config.size, config.size)
-	RaidIcon:SetPoint(config.anchor[1], Health, config.anchor[2], config.anchor[3], config.anchor[4])
-	RaidIcon:SetTexture([[Interface\AddOns\Tukui\Medias\Textures\Others\RaidIcons]])
+local function RaidTargetIndicator(unitFrame, config)
+	local health = unitFrame.Health
+	local raidIcon = health:CreateTexture(nil, "OVERLAY")
+	raidIcon:SetSize(config.size, config.size)
+	raidIcon:SetPoint(config.anchor[1], health, config.anchor[2], config.anchor[3], config.anchor[4])
+	raidIcon:SetTexture([[Interface\AddOns\Tukui\Medias\Textures\Others\RaidIcons]])
 
-	unitFrame.RaidTargetIndicator = RaidIcon
+	unitFrame.RaidTargetIndicator = raidIcon
 end
 
 -- Configures oUF element ReadyCheckIndicator.
-local function createReadyCheckIndicator(unitFrame, config)
-	local Power = unitFrame.Power
-	local ReadyCheck = Power:CreateTexture(nil, "OVERLAY", nil, 2)
-	ReadyCheck:SetSize(config.size, config.size)
-	ReadyCheck:SetPoint(config.anchor[1], Power, config.anchor[2], config.anchor[3], config.anchor[4])
+local function ReadyCheckIndicator(unitFrame, config)
+	local power = unitFrame.Power
+	local readyCheck = power:CreateTexture(nil, "OVERLAY", nil, 2)
+	readyCheck:SetSize(config.size, config.size)
+	readyCheck:SetPoint(config.anchor[1], power, config.anchor[2], config.anchor[3], config.anchor[4])
 
-	unitFrame.ReadyCheckIndicator = ReadyCheck
+	unitFrame.ReadyCheckIndicator = readyCheck
 end
 
 -- Configures oUF element ResurrectIndicator.
-local function createResurrectIndicator(unitFrame, config)
-	local Health = unitFrame.Health
-	local ResurrectIndicator = Health:CreateTexture(nil, "OVERLAY")
-	ResurrectIndicator:SetSize(config.size, config.size)
-	ResurrectIndicator:SetPoint(config.anchor[1], Health, config.anchor[2], config.anchor[3], config.anchor[4])
+local function ResurrectIndicator(unitFrame, config)
+	local health = unitFrame.Health
+	local resurrect = health:CreateTexture(nil, "OVERLAY")
+	resurrect:SetSize(config.size, config.size)
+	resurrect:SetPoint(config.anchor[1], health, config.anchor[2], config.anchor[3], config.anchor[4])
 
-	unitFrame.ResurrectIndicator = ResurrectIndicator
+	unitFrame.ResurrectIndicator = resurrect
 end
 
 -- Configures oUF element Range.
-local function createRange(unitFrame, config)
-	local Range = {
+local function Range(unitFrame, config)
+	local range = {
 		insideAlpha = 1,
 		outsideAlpha = config.outsideAlpha,
 	}
 
-	unitFrame.Range = Range
+	unitFrame.Range = range
 end
 
 -- Configures oUF element Buffs (part of Auras).
-local function createBuffs(unitFrame, config)
-	local Buffs = CreateFrame("Frame", unitFrame:GetName().."Buffs", unitFrame.Health)
+local function Buffs(unitFrame, config)
+	local buffs = CreateFrame("Frame", unitFrame:GetName().."Buffs", unitFrame.Health)
+	buffs:SetPoint(config.anchor[1], unitFrame.Health, config.anchor[2], config.anchor[3], config.anchor[4])
+	buffs:SetHeight(config.height)
+	buffs:SetWidth(config.width)
 
-	Buffs:SetPoint(config.anchor[1], unitFrame.Health, config.anchor[2], config.anchor[3], config.anchor[4])
-	Buffs:SetHeight(config.height)
-	Buffs:SetWidth(config.width)
-	Buffs.size = config.buffSize
-	Buffs.num = config.buffNum
-	Buffs.numRow = 1
-	Buffs.spacing = 0
-	Buffs.initialAnchor = "TOPLEFT"
-	Buffs.disableCooldown = true
-	Buffs.disableMouse = true
-	Buffs.onlyShowPlayer = config.onlyShowPlayer
-	Buffs.filter = config.filter
-	Buffs.PostCreateIcon = UnitFrames.PostCreateAura
-	Buffs.PostUpdateIcon = UnitFrames.DesaturateBuffs
-	Buffs.PostCreateButton = UnitFrames.PostCreateAura
-	Buffs.PostUpdateButton = UnitFrames.DesaturateBuffs
+	buffs.size = config.buffSize
+	buffs.num = config.buffNum
+	buffs.numRow = 1
+	buffs.spacing = 0
+	buffs.initialAnchor = "TOPLEFT"
+	buffs.disableCooldown = true
+	buffs.disableMouse = true
+	buffs.onlyShowPlayer = config.onlyShowPlayer
+	buffs.filter = config.filter
+	buffs.PostCreateIcon = UnitFrames.PostCreateAura
+	buffs.PostUpdateIcon = UnitFrames.DesaturateBuffs
+	buffs.PostCreateButton = UnitFrames.PostCreateAura
+	buffs.PostUpdateButton = UnitFrames.DesaturateBuffs
 
-	unitFrame.Buffs = Buffs
+	unitFrame.Buffs = buffs
 end
 
 -- Configures oUF element HealthPrediction.
-local function createHealComm(unitframe, config)
-	local Health = unitframe.Health
-	local myBar = CreateFrame("StatusBar", nil, Health)
-	local otherBar = CreateFrame("StatusBar", nil, Health)
-	local absorbBar = CreateFrame("StatusBar", nil, Health)
-	local Vertical = Health:GetOrientation() == "VERTICAL" and true or false
+local function HealComm(unitframe, config)
+	local health = unitframe.Health
+	local myBar = CreateFrame("StatusBar", nil, health)
+	local otherBar = CreateFrame("StatusBar", nil, health)
+	local absorbBar = CreateFrame("StatusBar", nil, health)
+	local vertical = health:GetOrientation() == "VERTICAL" and true or false
 
-	myBar:SetOrientation(Vertical and "VERTICAL" or "HORIZONTAL")
-	myBar:SetFrameLevel(Health:GetFrameLevel())
+	myBar:SetOrientation(vertical and "VERTICAL" or "HORIZONTAL")
+	myBar:SetFrameLevel(health:GetFrameLevel())
 	myBar:SetStatusBarTexture(HealthTexture)
-	myBar:SetPoint(Vertical and "LEFT" or "TOP")
-	myBar:SetPoint(Vertical and "RIGHT" or "BOTTOM")
-	myBar:SetPoint(Vertical and "BOTTOM" or "LEFT", Health:GetStatusBarTexture(), Vertical and "TOP" or "RIGHT")
+	myBar:SetPoint(vertical and "LEFT" or "TOP")
+	myBar:SetPoint(vertical and "RIGHT" or "BOTTOM")
+	myBar:SetPoint(vertical and "BOTTOM" or "LEFT", health:GetStatusBarTexture(), vertical and "TOP" or "RIGHT")
 	myBar:SetWidth(config.width)
 	myBar:SetStatusBarColor(unpack(C.UnitFrames.HealCommSelfColor))
 	myBar:SetMinMaxValues(0, 1)
 	myBar:SetValue(0)
 
-	otherBar:SetOrientation(Vertical and "VERTICAL" or "HORIZONTAL")
-	otherBar:SetFrameLevel(Health:GetFrameLevel())
-	otherBar:SetPoint(Vertical and "LEFT" or "TOP")
-	otherBar:SetPoint(Vertical and "RIGHT" or "BOTTOM")
-	otherBar:SetPoint(Vertical and "BOTTOM" or "LEFT", myBar:GetStatusBarTexture(), Vertical and "TOP" or "RIGHT")
+	otherBar:SetOrientation(vertical and "VERTICAL" or "HORIZONTAL")
+	otherBar:SetFrameLevel(health:GetFrameLevel())
+	otherBar:SetPoint(vertical and "LEFT" or "TOP")
+	otherBar:SetPoint(vertical and "RIGHT" or "BOTTOM")
+	otherBar:SetPoint(vertical and "BOTTOM" or "LEFT", myBar:GetStatusBarTexture(), vertical and "TOP" or "RIGHT")
 	otherBar:SetWidth(config.width)
 	otherBar:SetStatusBarTexture(HealthTexture)
 	otherBar:SetStatusBarColor(unpack(C.UnitFrames.HealCommOtherColor))
 	otherBar:SetMinMaxValues(0, 1)
 	otherBar:SetValue(0)
 
-	absorbBar:SetOrientation(Vertical and "VERTICAL" or "HORIZONTAL")
-	absorbBar:SetFrameLevel(Health:GetFrameLevel())
-	absorbBar:SetPoint(Vertical and "LEFT" or "TOP")
-	absorbBar:SetPoint(Vertical and "RIGHT" or "BOTTOM")
-	absorbBar:SetPoint(Vertical and "BOTTOM" or "LEFT", otherBar:GetStatusBarTexture(), Vertical and "TOP" or "RIGHT")
+	absorbBar:SetOrientation(vertical and "VERTICAL" or "HORIZONTAL")
+	absorbBar:SetFrameLevel(health:GetFrameLevel())
+	absorbBar:SetPoint(vertical and "LEFT" or "TOP")
+	absorbBar:SetPoint(vertical and "RIGHT" or "BOTTOM")
+	absorbBar:SetPoint(vertical and "BOTTOM" or "LEFT", otherBar:GetStatusBarTexture(), vertical and "TOP" or "RIGHT")
 	absorbBar:SetWidth(config.width)
 	absorbBar:SetStatusBarTexture(HealthTexture)
 	absorbBar:SetStatusBarColor(unpack(C.UnitFrames.HealCommAbsorbColor))
@@ -191,80 +192,80 @@ end
 
 -- oUF Plugins
 -- Configures oUF_AuraTrack.
-local function createAuraTrack(unitFrame, config)
-	local AuraTrack = CreateFrame("Frame", nil, unitFrame.Health)
-	AuraTrack:SetAllPoints()
-	AuraTrack.Texture = C.Medias.Normal
-	AuraTrack.Font = C.Medias.Font
-	AuraTrack.Icons = config.icons
-	AuraTrack.SpellTextures = config.texture
-	AuraTrack.Thickness = config.thickness
+local function AuraTrack(unitFrame, config)
+	local auraTrack = CreateFrame("Frame", nil, unitFrame.Health)
+	auraTrack:SetAllPoints()
+	auraTrack.Texture = C.Medias.Normal
+	auraTrack.Font = C.Medias.Font
+	auraTrack.Icons = config.icons
+	auraTrack.SpellTextures = config.texture
+	auraTrack.Thickness = config.thickness
 
-	unitFrame.AuraTrack = AuraTrack
+	unitFrame.AuraTrack = auraTrack
 end
 
 -- Configures oUF_RaidDebuffs.
-local function createRaidDebuffs(unitFrame, config)
-	local Health = unitFrame.Health
-	local RaidDebuffs = CreateFrame("Frame", nil, Health)
+local function RaidDebuffs(unitFrame, config)
+	local health = unitFrame.Health
+	local raidDebuffs = CreateFrame("Frame", nil, health)
 
-	RaidDebuffs:SetSize(config.size, config.size)
-	RaidDebuffs:SetPoint(config.anchor[1], config.anchor[2], config.anchor[3], config.anchor[4])
-	RaidDebuffs:SetFrameLevel(Health:GetFrameLevel() + 10)
-	RaidDebuffs.icon = RaidDebuffs:CreateTexture(nil, "ARTWORK")
-	RaidDebuffs.icon:SetTexCoord(.1, .9, .1, .9)
-	RaidDebuffs.icon:SetInside(RaidDebuffs)
-	RaidDebuffs.cd = CreateFrame("Cooldown", nil, RaidDebuffs, "CooldownFrameTemplate")
-	RaidDebuffs.cd:SetInside(RaidDebuffs, 1, 0)
-	RaidDebuffs.cd:SetReverse(true)
-	RaidDebuffs.cd:SetHideCountdownNumbers(true)
-	RaidDebuffs.cd:SetAlpha(.7)
-	RaidDebuffs.timer = RaidDebuffs:CreateFontString(nil, "OVERLAY")
-	RaidDebuffs.timer:SetFont(C.Medias.Font, 12, "OUTLINE")
-	RaidDebuffs.timer:SetPoint("CENTER", RaidDebuffs, 1, 0)
-	RaidDebuffs.count = RaidDebuffs:CreateFontString(nil, "OVERLAY")
-	RaidDebuffs.count:SetFont(C.Medias.Font, 12, "OUTLINE")
-	RaidDebuffs.count:SetPoint("BOTTOMRIGHT", RaidDebuffs, "BOTTOMRIGHT", 2, 0)
-	RaidDebuffs.count:SetTextColor(1, .9, 0)
+	raidDebuffs:SetSize(config.size, config.size)
+	raidDebuffs:SetPoint(config.anchor[1], config.anchor[2], config.anchor[3], config.anchor[4])
+	raidDebuffs:SetFrameLevel(health:GetFrameLevel() + 10)
+	raidDebuffs.icon = raidDebuffs:CreateTexture(nil, "ARTWORK")
+	raidDebuffs.icon:SetTexCoord(.1, .9, .1, .9)
+	raidDebuffs.icon:SetInside(raidDebuffs)
+	raidDebuffs.cd = CreateFrame("Cooldown", nil, raidDebuffs, "CooldownFrameTemplate")
+	raidDebuffs.cd:SetInside(raidDebuffs, 1, 0)
+	raidDebuffs.cd:SetReverse(true)
+	raidDebuffs.cd:SetHideCountdownNumbers(true)
+	raidDebuffs.cd:SetAlpha(.7)
+	raidDebuffs.timer = raidDebuffs:CreateFontString(nil, "OVERLAY")
+	raidDebuffs.timer:SetFont(C.Medias.Font, 12, "OUTLINE")
+	raidDebuffs.timer:SetPoint("CENTER", raidDebuffs, 1, 0)
+	raidDebuffs.count = raidDebuffs:CreateFontString(nil, "OVERLAY")
+	raidDebuffs.count:SetFont(C.Medias.Font, 12, "OUTLINE")
+	raidDebuffs.count:SetPoint("BOTTOMRIGHT", raidDebuffs, "BOTTOMRIGHT", 2, 0)
+	raidDebuffs.count:SetTextColor(1, .9, 0)
 
-	unitFrame.RaidDebuffs = RaidDebuffs
+	unitFrame.RaidDebuffs = raidDebuffs
 end
 
 
 -- additional plugins
 -- Creates a panel for the unit name.
-local function createNamePanel(unitFrame, config)
-	local Panel = CreateFrame("Frame", nil, unitFrame)
-	Panel:SetPoint("TOPLEFT", unitFrame.Power, "BOTTOMLEFT", 0, -1)
-	Panel:SetPoint("TOPRIGHT", unitFrame.Power, "BOTTOMRIGHT", 0, -1)
-	Panel:SetPoint("BOTTOM", 0, 0)
-	Panel:CreateBackdrop()
-	Panel.Backdrop:SetBorderColor(0, 0, 0, 0)
+local function NamePanel(unitFrame, config)
+	local panel = CreateFrame("Frame", nil, unitFrame)
+	panel:SetPoint("TOPLEFT", unitFrame.Power, "BOTTOMLEFT", 0, -1)
+	panel:SetPoint("TOPRIGHT", unitFrame.Power, "BOTTOMRIGHT", 0, -1)
+	panel:SetPoint("BOTTOM", 0, 0)
+	panel:CreateBackdrop()
+	panel.Backdrop:SetBorderColor(0, 0, 0, 0)
 
-	local Name = Panel:CreateFontString(nil, "OVERLAY")
-	Name:SetPoint(config.nameAnchor)
-	Name:SetFontObject(Font)
+	local name = panel:CreateFontString(nil, "OVERLAY")
+	name:SetPoint(config.nameAnchor)
+	name:SetFontObject(Font)
 
-	unitFrame.Panel = Panel
-	unitFrame.Name = Name
+	unitFrame.Panel = panel
+	unitFrame.Name = name
 
 	if T.Retail then
-		unitFrame:Tag(Name, "[Tukui:GetRaidNameColor][Tukui:NameShort]")
+		unitFrame:Tag(name, "[Tukui:GetRaidNameColor][Tukui:NameShort]")
 	else
-		unitFrame:Tag(Name, "[Tukui:NameShort]")
+		unitFrame:Tag(name, "[Tukui:NameShort]")
 	end
 end
 
 -- Highlights the currently selected unit.
-local function createHighlight(unitFrame, config)
-	local Highlight = CreateFrame("Frame", nil, unitFrame, "BackdropTemplate")
-	Highlight:SetBackdrop({edgeFile = C.Medias.Glow, edgeSize = config.size})
-	Highlight:SetOutside(unitFrame, config.size, config.size)
-	Highlight:SetBackdropBorderColor(unpack(config.color))
-	Highlight:SetFrameLevel(0)
-	Highlight:Hide()
+local function Highlight(unitFrame, config)
+	local highlight = CreateFrame("Frame", nil, unitFrame, "BackdropTemplate")
+	highlight:SetBackdrop({edgeFile = C.Medias.Glow, edgeSize = config.size})
+	highlight:SetOutside(unitFrame, config.size, config.size)
+	highlight:SetBackdropBorderColor(unpack(config.color))
+	highlight:SetFrameLevel(0)
+	highlight:Hide()
 
-	unitFrame.Highlight = Highlight
+	unitFrame.Highlight = highlight
 end
 
 -- Create new WidgetManager for Raid and expose for external edits.
@@ -290,32 +291,32 @@ function UnitFrames.Raid(self)
 	self.Backdrop:SetBackdrop(UnitFrames.Backdrop)
 	self.Backdrop:SetBackdropColor(0, 0, 0)
 
-	RaidWidgets:add("Health", createHealth, { height = C.Raid.HeightSize - 1 - 3 - 1 -18,  -- border, power, border, namepanel
+	RaidWidgets:add("Health", Health, { height = C.Raid.HeightSize - 1 - 3 - 1 -18,  -- border, power, border, namepanel
 		valueFont = HealthFont, valueAnchor = {"CENTER", 0, -6}, Tag = C.Raid.HealthTag.Value })
-	RaidWidgets:add("Power", createPower, {})
-	RaidWidgets:add("NamePanel", createNamePanel, { nameAnchor = "CENTER" })
+	RaidWidgets:add("Power", Power, {})
+	RaidWidgets:add("NamePanel", NamePanel, { nameAnchor = "CENTER" })
 
-	RaidWidgets:add("RaidTargetIndicator", createRaidTargetIndicator, { size = C.UnitFrames.RaidIconSize, anchor = {"TOP", 0, C.UnitFrames.RaidIconSize / 2} })
-	RaidWidgets:add("ReadyCheckIndicator", createReadyCheckIndicator, { size = 12, anchor = {"CENTER"} })
-	RaidWidgets:add("ResurrectIndicator", createResurrectIndicator, { size = 24, anchor = {"CENTER"} })
-	RaidWidgets:add("Range", createRange, { outsideAlpha = C["Raid"].RangeAlpha })
-	RaidWidgets:add("Highlight", createHighlight, { size = C.Raid.HighlightSize, color = C.Raid.HighlightColor })
+	RaidWidgets:add("RaidTargetIndicator", RaidTargetIndicator, { size = C.UnitFrames.RaidIconSize, anchor = {"TOP", 0, C.UnitFrames.RaidIconSize / 2} })
+	RaidWidgets:add("ReadyCheckIndicator", ReadyCheckIndicator, { size = 12, anchor = {"CENTER"} })
+	RaidWidgets:add("ResurrectIndicator", ResurrectIndicator, { size = 24, anchor = {"CENTER"} })
+	RaidWidgets:add("Range", Range, { outsideAlpha = C["Raid"].RangeAlpha })
+	RaidWidgets:add("Highlight", Highlight, { size = C.Raid.HighlightSize, color = C.Raid.HighlightColor })
 
 	if C.UnitFrames.HealComm then
-		RaidWidgets:add("HealComm", createHealComm, { width = C.Raid.WidthSize })
+		RaidWidgets:add("HealComm", HealComm, { width = C.Raid.WidthSize })
 	end
 
 	if C.Raid.RaidBuffsStyle.Value == "Standard" then
-		RaidWidgets:add("Buffs", createBuffs, { filter = C.Raid.RaidBuffs.Value == "All" and "HELPFUL" or "HELPFUL|RAID",
+		RaidWidgets:add("Buffs", Buffs, { filter = C.Raid.RaidBuffs.Value == "All" and "HELPFUL" or "HELPFUL|RAID",
 			onlyShowPlayer = C.Raid.RaidBuffs.Value == "Self", height = 16, width = 79, anchor = {"TOPLEFT"},
 			buffSize = 16, buffNum = 5 })
 	elseif C.Raid.RaidBuffsStyle.Value == "Aura Track" then
-		RaidWidgets:add("AuraTrack", createAuraTrack, { icons = C.Raid.AuraTrackIcons, texture = C.Raid.AuraTrackSpellTextures, thickness = C.Raid.AuraTrackThickness })
+		RaidWidgets:add("AuraTrack", AuraTrack, { icons = C.Raid.AuraTrackIcons, texture = C.Raid.AuraTrackSpellTextures, thickness = C.Raid.AuraTrackThickness })
 	end
 
 	if C.Raid.DebuffWatch then
 		local height = C.Raid.HeightSize - 1 - 3 - 1 -18  -- border, power, border, namepanel
-		RaidWidgets:add("RaidDebuffs", createRaidDebuffs, { size = height >= 32 and height - 16 or height, anchor = {"CENTER"} })
+		RaidWidgets:add("RaidDebuffs", RaidDebuffs, { size = height >= 32 and height - 16 or height, anchor = {"CENTER"} })
 	end
 
 	RaidWidgets:createWidgets(self)

--- a/Tukui/Modules/UnitFrames/Groups/Raid.lua
+++ b/Tukui/Modules/UnitFrames/Groups/Raid.lua
@@ -35,7 +35,6 @@ local function createHealth(unitFrame, config)
 	Health.colorDisconnected = true
 	Health.colorClass = true
 	Health.colorReaction = true
-	Health.isRaid = config.isRaid or false
 	if C.UnitFrames.Smoothing then
 		Health.smoothing = true
 	end
@@ -60,7 +59,6 @@ local function createPower(unitFrame, config)
 	Power:SetStatusBarTexture(PowerTexture)
 
 	Power.colorPower = true
-	Power.isRaid = config.isRaid or false
 	if C.UnitFrames.Smoothing then
 		Power.smoothing = true
 	end
@@ -126,7 +124,6 @@ local function createBuffs(unitFrame, config)
 	Buffs.disableMouse = true
 	Buffs.onlyShowPlayer = config.onlyShowPlayer
 	Buffs.filter = config.filter
-	Buffs.IsRaid = config.isRaid
 	Buffs.PostCreateIcon = UnitFrames.PostCreateAura
 	Buffs.PostUpdateIcon = UnitFrames.DesaturateBuffs
 	Buffs.PostCreateButton = UnitFrames.PostCreateAura
@@ -295,8 +292,8 @@ function UnitFrames.Raid(self)
 
 	-- oUF base elements
 	RaidWidgets:add("Health", createHealth, { height = C.Raid.HeightSize - 1 - 3 - 1 -18,  -- border, power, border, namepanel
-		valueFont = HealthFont, valueAnchor = {"CENTER", 0, -6}, isRaid = true, Tag = C.Raid.HealthTag.Value })
-	RaidWidgets:add("Power", createPower, { isRaid = true})
+		valueFont = HealthFont, valueAnchor = {"CENTER", 0, -6}, Tag = C.Raid.HealthTag.Value })
+	RaidWidgets:add("Power", createPower, {})
 	RaidWidgets:add("RaidTargetIndicator", createRaidTargetIndicator, { size = C.UnitFrames.RaidIconSize, anchor = {"TOP", 0, C.UnitFrames.RaidIconSize / 2} })
 	RaidWidgets:add("ReadyCheckIndicator", createReadyCheckIndicator, { size = 12, anchor = {"CENTER"} })
 	RaidWidgets:add("ResurrectIndicator", createResurrectIndicator, { size = 24, anchor = {"CENTER"} })
@@ -304,7 +301,7 @@ function UnitFrames.Raid(self)
 	if C.Raid.RaidBuffsStyle.Value == "Standard" then
 		RaidWidgets:add("Buffs", createBuffs, { filter = C.Raid.RaidBuffs.Value == "All" and "HELPFUL" or "HELPFUL|RAID",
 			onlyShowPlayer = C.Raid.RaidBuffs.Value == "Self", height = 16, width = 79, anchor = {"TOPLEFT"},
-			buffSize = 16, buffNum = 5, isRaid = true })
+			buffSize = 16, buffNum = 5 })
 	end
 	if C.UnitFrames.HealComm then
 		RaidWidgets:add("HealComm", createHealComm, { width = C.Raid.WidthSize })

--- a/Tukui/Modules/UnitFrames/Groups/Raid.lua
+++ b/Tukui/Modules/UnitFrames/Groups/Raid.lua
@@ -295,32 +295,71 @@ function UnitFrames.Raid(self)
 	self.Backdrop:SetBackdrop(UnitFrames.Backdrop)
 	self.Backdrop:SetBackdropColor(0, 0, 0)
 
-	RaidWidgets:add("Health", Health, { height = C.Raid.HeightSize - 1 - 3 - 1 -18,  -- border, power, border, namepanel
-		valueFont = HealthFont, valueAnchor = {"CENTER", 0, -6}, Tag = C.Raid.HealthTag.Value })
-	RaidWidgets:add("Power", Power, {})
-	RaidWidgets:add("NamePanel", NamePanel, { nameAnchor = "CENTER" })
+	local config = {
+		Health = {
+			height = C.Raid.HeightSize - 1 - 3 - 1 -18,  -- border, power, border, namepanel
+			valueFont = HealthFont,
+			valueAnchor = {"CENTER", 0, -6},
+			Tag = C.Raid.HealthTag.Value, },
+		Power = {
+			},
+		NamePanel = {
+			nameAnchor = "CENTER", },
+		RaidTargetIndicator = {
+			size = C.UnitFrames.RaidIconSize,
+			anchor = {"TOP", 0, C.UnitFrames.RaidIconSize / 2}, },
+		ReadyCheckIndicator = {
+			size = 12,
+			anchor = {"CENTER"}, },
+		ResurrectIndicator = {
+			size = 24,
+			anchor = {"CENTER"}, },
+		Range = {
+			outsideAlpha = C["Raid"].RangeAlpha, },
+		Highlight = {
+			size = C.Raid.HighlightSize,
+			color = C.Raid.HighlightColor, },
+		HealComm = {
+			width = C.Raid.WidthSize, },
+		Buffs = {
+			height = 16,
+			width = 79,
+			anchor = {"TOPLEFT"},
+			buffSize = 16,
+			buffNum = 5,
+			filter = C.Raid.RaidBuffs.Value == "All" and "HELPFUL" or "HELPFUL|RAID",
+			onlyShowPlayer = C.Raid.RaidBuffs.Value == "Self", },
+		AuraTrack = {
+			icons = C.Raid.AuraTrackIcons,
+			texture = C.Raid.AuraTrackSpellTextures,
+			thickness = C.Raid.AuraTrackThickness, },
+		RaidDebuffs = {
+			size = 24,
+			anchor = {"CENTER"}, },
+	}
 
-	RaidWidgets:add("RaidTargetIndicator", RaidTargetIndicator, { size = C.UnitFrames.RaidIconSize, anchor = {"TOP", 0, C.UnitFrames.RaidIconSize / 2} })
-	RaidWidgets:add("ReadyCheckIndicator", ReadyCheckIndicator, { size = 12, anchor = {"CENTER"} })
-	RaidWidgets:add("ResurrectIndicator", ResurrectIndicator, { size = 24, anchor = {"CENTER"} })
-	RaidWidgets:add("Range", Range, { outsideAlpha = C["Raid"].RangeAlpha })
-	RaidWidgets:add("Highlight", Highlight, { size = C.Raid.HighlightSize, color = C.Raid.HighlightColor })
+	RaidWidgets:add("Health", Health, config.Health)
+	RaidWidgets:add("Power", Power, config.Power)
+	RaidWidgets:add("NamePanel", NamePanel, config.NamePanel)
+
+	RaidWidgets:add("RaidTargetIndicator", RaidTargetIndicator, config.RaidTargetIndicator)
+	RaidWidgets:add("ReadyCheckIndicator", ReadyCheckIndicator, config.ReadyCheckIndicator)
+	RaidWidgets:add("ResurrectIndicator", ResurrectIndicator, config.ResurrectIndicator)
+	RaidWidgets:add("Range", Range, config.Range)
+	RaidWidgets:add("Highlight", Highlight, config.Highlight)
 
 	if C.UnitFrames.HealComm then
-		RaidWidgets:add("HealComm", HealComm, { width = C.Raid.WidthSize })
+		RaidWidgets:add("HealComm", HealComm, config.HealComm)
 	end
 
 	if C.Raid.RaidBuffsStyle.Value == "Standard" then
-		RaidWidgets:add("Buffs", Buffs, { filter = C.Raid.RaidBuffs.Value == "All" and "HELPFUL" or "HELPFUL|RAID",
-			onlyShowPlayer = C.Raid.RaidBuffs.Value == "Self", height = 16, width = 79, anchor = {"TOPLEFT"},
-			buffSize = 16, buffNum = 5 })
+		RaidWidgets:add("Buffs", Buffs, config.Buffs)
 	elseif C.Raid.RaidBuffsStyle.Value == "Aura Track" then
-		RaidWidgets:add("AuraTrack", AuraTrack, { icons = C.Raid.AuraTrackIcons, texture = C.Raid.AuraTrackSpellTextures, thickness = C.Raid.AuraTrackThickness })
+		RaidWidgets:add("AuraTrack", AuraTrack, config.AuraTrack)
 	end
 
 	if C.Raid.DebuffWatch then
-		local height = C.Raid.HeightSize - 1 - 3 - 1 -18  -- border, power, border, namepanel
-		RaidWidgets:add("RaidDebuffs", RaidDebuffs, { size = height >= 32 and height - 16 or height, anchor = {"CENTER"} })
+		RaidWidgets:add("RaidDebuffs", RaidDebuffs, config.RaidDebuffs)
 	end
 
 	RaidWidgets:createWidgets(self)

--- a/Tukui/Modules/UnitFrames/Groups/Raid.lua
+++ b/Tukui/Modules/UnitFrames/Groups/Raid.lua
@@ -12,11 +12,11 @@ local HealthFont
 
 -- oUF base elements
 -- Configures oUF element Health.
-local function createHealth(unitFrame)
+local function createHealth(unitFrame, config)
 	local Health = CreateFrame("StatusBar", nil, unitFrame)
 	Health:SetPoint("TOPLEFT")
 	Health:SetPoint("TOPRIGHT")
-	Health:SetHeight(unitFrame:GetHeight() - 3 - 19)
+	Health:SetHeight(config.height)
 	Health:SetStatusBarTexture(HealthTexture)
 
 	if C.Raid.VerticalHealth then
@@ -29,26 +29,26 @@ local function createHealth(unitFrame)
 	Health.Background.multiplier = C.UnitFrames.StatusBarBackgroundMultiplier / 100
 
 	Health.Value = Health:CreateFontString(nil, "OVERLAY")
-	Health.Value:SetFontObject(HealthFont)
-	Health.Value:SetPoint("CENTER", Health, "CENTER", 0, -6)
+	Health.Value:SetFontObject(config.valueFont)
+	Health.Value:SetPoint(config.valueAnchor[1], Health, config.valueAnchor[2], config.valueAnchor[3], config.valueAnchor[4])
 
 	Health.colorDisconnected = true
 	Health.colorClass = true
 	Health.colorReaction = true
-	Health.isRaid = true
+	Health.isRaid = config.isRaid or false
 	if C.UnitFrames.Smoothing then
 		Health.smoothing = true
 	end
 
 	unitFrame.Health = Health
 	unitFrame.Health.bg = Health.Background
-	unitFrame:Tag(Health.Value, C.Raid.HealthTag.Value)
+	unitFrame:Tag(Health.Value, config.Tag)
 end
 
 -- Configures oUF element Power.
-local function createPower(unitFrame)
+local function createPower(unitFrame, config)
 	local Power = CreateFrame("StatusBar", nil, unitFrame)
-	Power:SetHeight(3)
+	Power:SetHeight(config.height or 3)
 	Power:SetPoint("TOPLEFT", unitFrame.Health, "BOTTOMLEFT", 0, -1)
 	Power:SetPoint("TOPRIGHT", unitFrame.Health, "BOTTOMRIGHT", 0, -1)
 
@@ -60,7 +60,7 @@ local function createPower(unitFrame)
 	Power:SetStatusBarTexture(PowerTexture)
 
 	Power.colorPower = true
-	Power.isRaid = true
+	Power.isRaid = config.isRaid or false
 	if C.UnitFrames.Smoothing then
 		Power.smoothing = true
 	end
@@ -70,63 +70,63 @@ local function createPower(unitFrame)
 end
 
 -- Configures oUF element RaidTargetIndicator.
-local function createRaidTargetIndicator(unitFrame)
-	local RaidIcon = unitFrame.Health:CreateTexture(nil, "OVERLAY")
-	RaidIcon:SetSize(C.UnitFrames.RaidIconSize, C.UnitFrames.RaidIconSize)
-	RaidIcon:SetPoint("TOP", unitFrame, 0, C.UnitFrames.RaidIconSize / 2)
+local function createRaidTargetIndicator(unitFrame, config)
+	local Health = unitFrame.Health
+	local RaidIcon = Health:CreateTexture(nil, "OVERLAY")
+	RaidIcon:SetSize(config.size, config.size)
+	RaidIcon:SetPoint(config.anchor[1], Health, config.anchor[2], config.anchor[3], config.anchor[4])
 	RaidIcon:SetTexture([[Interface\AddOns\Tukui\Medias\Textures\Others\RaidIcons]])
 
 	unitFrame.RaidTargetIndicator = RaidIcon
 end
 
 -- Configures oUF element ReadyCheckIndicator.
-local function createReadyCheckIndicator(unitFrame)
-	local ReadyCheck = unitFrame.Power:CreateTexture(nil, "OVERLAY", nil, 2)
-	ReadyCheck:SetSize(12, 12)
-	ReadyCheck:SetPoint("CENTER")
+local function createReadyCheckIndicator(unitFrame, config)
+	local Power = unitFrame.Power
+	local ReadyCheck = Power:CreateTexture(nil, "OVERLAY", nil, 2)
+	ReadyCheck:SetSize(config.size, config.size)
+	ReadyCheck:SetPoint(config.anchor[1], Power, config.anchor[2], config.anchor[3], config.anchor[4])
 
 	unitFrame.ReadyCheckIndicator = ReadyCheck
 end
 
 -- Configures oUF element ResurrectIndicator.
-local function createResurrectIndicator(unitFrame)
+local function createResurrectIndicator(unitFrame, config)
 	local Health = unitFrame.Health
 	local ResurrectIndicator = Health:CreateTexture(nil, "OVERLAY")
-	ResurrectIndicator:SetSize(24, 24)
-	ResurrectIndicator:SetPoint("CENTER", Health)
+	ResurrectIndicator:SetSize(config.size, config.size)
+	ResurrectIndicator:SetPoint(config.anchor[1], Health, config.anchor[2], config.anchor[3], config.anchor[4])
 
 	unitFrame.ResurrectIndicator = ResurrectIndicator
 end
 
 -- Configures oUF element Range.
-local function createRange(unitFrame)
+local function createRange(unitFrame, config)
 	local Range = {
 		insideAlpha = 1,
-		outsideAlpha = C["Raid"].RangeAlpha,
+		outsideAlpha = config.outsideAlpha,
 	}
 
 	unitFrame.Range = Range
 end
 
 -- Configures oUF element Buffs (part of Auras).
-local function createBuffs(unitFrame)
+local function createBuffs(unitFrame, config)
 	local Buffs = CreateFrame("Frame", unitFrame:GetName().."Buffs", unitFrame.Health)
-	local onlyShowPlayer = C.Raid.RaidBuffs.Value == "Self"
-	local filter = C.Raid.RaidBuffs.Value == "All" and "HELPFUL" or "HELPFUL|RAID"
 
-	Buffs:SetPoint("TOPLEFT", unitFrame.Health, "TOPLEFT", 0, 0)
-	Buffs:SetHeight(16)
-	Buffs:SetWidth(79)
-	Buffs.size = 16
-	Buffs.num = 5
+	Buffs:SetPoint(config.anchor[1], unitFrame.Health, config.anchor[2], config.anchor[3], config.anchor[4])
+	Buffs:SetHeight(config.height)
+	Buffs:SetWidth(config.width)
+	Buffs.size = config.buffSize
+	Buffs.num = config.buffNum
 	Buffs.numRow = 1
 	Buffs.spacing = 0
 	Buffs.initialAnchor = "TOPLEFT"
 	Buffs.disableCooldown = true
 	Buffs.disableMouse = true
-	Buffs.onlyShowPlayer = onlyShowPlayer
-	Buffs.filter = filter
-	Buffs.IsRaid = true
+	Buffs.onlyShowPlayer = config.onlyShowPlayer
+	Buffs.filter = config.filter
+	Buffs.IsRaid = config.isRaid
 	Buffs.PostCreateIcon = UnitFrames.PostCreateAura
 	Buffs.PostUpdateIcon = UnitFrames.DesaturateBuffs
 	Buffs.PostCreateButton = UnitFrames.PostCreateAura
@@ -136,92 +136,83 @@ local function createBuffs(unitFrame)
 end
 
 -- Configures oUF element HealthPrediction.
-local function createHealComm(unitframe)
-	if C.UnitFrames.HealComm then
-		local Health = unitframe.Health
-		local myBar = CreateFrame("StatusBar", nil, Health)
-		local otherBar = CreateFrame("StatusBar", nil, Health)
-		local absorbBar = CreateFrame("StatusBar", nil, Health)
-		local Vertical = Health:GetOrientation() == "VERTICAL" and true or false
+local function createHealComm(unitframe, config)
+	local Health = unitframe.Health
+	local myBar = CreateFrame("StatusBar", nil, Health)
+	local otherBar = CreateFrame("StatusBar", nil, Health)
+	local absorbBar = CreateFrame("StatusBar", nil, Health)
+	local Vertical = Health:GetOrientation() == "VERTICAL" and true or false
 
-		myBar:SetOrientation(Vertical and "VERTICAL" or "HORIZONTAL")
-		myBar:SetFrameLevel(Health:GetFrameLevel())
-		myBar:SetStatusBarTexture(HealthTexture)
-		myBar:SetPoint(Vertical and "LEFT" or "TOP")
-		myBar:SetPoint(Vertical and "RIGHT" or "BOTTOM")
-		myBar:SetPoint(Vertical and "BOTTOM" or "LEFT", Health:GetStatusBarTexture(), Vertical and "TOP" or "RIGHT")
-		myBar:SetWidth(C.Raid.WidthSize)
-		myBar:SetStatusBarColor(unpack(C.UnitFrames.HealCommSelfColor))
-		myBar:SetMinMaxValues(0, 1)
-		myBar:SetValue(0)
+	myBar:SetOrientation(Vertical and "VERTICAL" or "HORIZONTAL")
+	myBar:SetFrameLevel(Health:GetFrameLevel())
+	myBar:SetStatusBarTexture(HealthTexture)
+	myBar:SetPoint(Vertical and "LEFT" or "TOP")
+	myBar:SetPoint(Vertical and "RIGHT" or "BOTTOM")
+	myBar:SetPoint(Vertical and "BOTTOM" or "LEFT", Health:GetStatusBarTexture(), Vertical and "TOP" or "RIGHT")
+	myBar:SetWidth(config.width)
+	myBar:SetStatusBarColor(unpack(C.UnitFrames.HealCommSelfColor))
+	myBar:SetMinMaxValues(0, 1)
+	myBar:SetValue(0)
 
-		otherBar:SetOrientation(Vertical and "VERTICAL" or "HORIZONTAL")
-		otherBar:SetFrameLevel(Health:GetFrameLevel())
-		otherBar:SetPoint(Vertical and "LEFT" or "TOP")
-		otherBar:SetPoint(Vertical and "RIGHT" or "BOTTOM")
-		otherBar:SetPoint(Vertical and "BOTTOM" or "LEFT", myBar:GetStatusBarTexture(), Vertical and "TOP" or "RIGHT")
-		otherBar:SetWidth(C.Raid.WidthSize)
-		otherBar:SetStatusBarTexture(HealthTexture)
-		otherBar:SetStatusBarColor(unpack(C.UnitFrames.HealCommOtherColor))
-		otherBar:SetMinMaxValues(0, 1)
-		otherBar:SetValue(0)
+	otherBar:SetOrientation(Vertical and "VERTICAL" or "HORIZONTAL")
+	otherBar:SetFrameLevel(Health:GetFrameLevel())
+	otherBar:SetPoint(Vertical and "LEFT" or "TOP")
+	otherBar:SetPoint(Vertical and "RIGHT" or "BOTTOM")
+	otherBar:SetPoint(Vertical and "BOTTOM" or "LEFT", myBar:GetStatusBarTexture(), Vertical and "TOP" or "RIGHT")
+	otherBar:SetWidth(config.width)
+	otherBar:SetStatusBarTexture(HealthTexture)
+	otherBar:SetStatusBarColor(unpack(C.UnitFrames.HealCommOtherColor))
+	otherBar:SetMinMaxValues(0, 1)
+	otherBar:SetValue(0)
 
-		absorbBar:SetOrientation(Vertical and "VERTICAL" or "HORIZONTAL")
-		absorbBar:SetFrameLevel(Health:GetFrameLevel())
-		absorbBar:SetPoint(Vertical and "LEFT" or "TOP")
-		absorbBar:SetPoint(Vertical and "RIGHT" or "BOTTOM")
-		absorbBar:SetPoint(Vertical and "BOTTOM" or "LEFT", otherBar:GetStatusBarTexture(), Vertical and "TOP" or "RIGHT")
-		absorbBar:SetWidth(C.Raid.WidthSize)
-		absorbBar:SetStatusBarTexture(HealthTexture)
-		absorbBar:SetStatusBarColor(unpack(C.UnitFrames.HealCommAbsorbColor))
-		absorbBar:SetMinMaxValues(0, 1)
-		absorbBar:SetValue(0)
+	absorbBar:SetOrientation(Vertical and "VERTICAL" or "HORIZONTAL")
+	absorbBar:SetFrameLevel(Health:GetFrameLevel())
+	absorbBar:SetPoint(Vertical and "LEFT" or "TOP")
+	absorbBar:SetPoint(Vertical and "RIGHT" or "BOTTOM")
+	absorbBar:SetPoint(Vertical and "BOTTOM" or "LEFT", otherBar:GetStatusBarTexture(), Vertical and "TOP" or "RIGHT")
+	absorbBar:SetWidth(config.width)
+	absorbBar:SetStatusBarTexture(HealthTexture)
+	absorbBar:SetStatusBarColor(unpack(C.UnitFrames.HealCommAbsorbColor))
+	absorbBar:SetMinMaxValues(0, 1)
+	absorbBar:SetValue(0)
 
-		local HealthPrediction = {
-			myBar = myBar,
-			otherBar = otherBar,
-			absorbBar = absorbBar,
-			maxOverflow = 1,
-		}
+	local HealthPrediction = {
+		myBar = myBar,
+		otherBar = otherBar,
+		absorbBar = absorbBar,
+		maxOverflow = 1,
+	}
 
-		unitframe.HealthPrediction = HealthPrediction
-	end
+	unitframe.HealthPrediction = HealthPrediction
 
 	-- Enable smoothing bars animation?
 	if C.UnitFrames.Smoothing then
-		unitframe.Health.smoothing = true
-		unitframe.Power.smoothing = true
-
-		if unitframe.HealthPrediction then
-			unitframe.HealthPrediction.smoothing = true
-		end
+		unitframe.HealthPrediction.smoothing = true
 	end
 end
 
 
 -- oUF Plugins
 -- Configures oUF_AuraTrack.
-local function createAuraTrack(unitFrame)
+local function createAuraTrack(unitFrame, config)
 	local AuraTrack = CreateFrame("Frame", nil, unitFrame.Health)
 	AuraTrack:SetAllPoints()
 	AuraTrack.Texture = C.Medias.Normal
-	AuraTrack.Icons = C.Raid.AuraTrackIcons
-	AuraTrack.SpellTextures = C.Raid.AuraTrackSpellTextures
-	AuraTrack.Thickness = C.Raid.AuraTrackThickness
 	AuraTrack.Font = C.Medias.Font
+	AuraTrack.Icons = config.icons
+	AuraTrack.SpellTextures = config.texture
+	AuraTrack.Thickness = config.thickness
 
 	unitFrame.AuraTrack = AuraTrack
 end
 
 -- Configures oUF_RaidDebuffs.
-local function createRaidDebuffs(unitFrame)
+local function createRaidDebuffs(unitFrame, config)
 	local Health = unitFrame.Health
 	local RaidDebuffs = CreateFrame("Frame", nil, Health)
-	local Height = Health:GetHeight()
-	local DebuffSize = Height >= 32 and Height - 16 or Height
 
-	RaidDebuffs:SetSize(DebuffSize, DebuffSize)
-	RaidDebuffs:SetPoint("CENTER", Health)
+	RaidDebuffs:SetSize(config.size, config.size)
+	RaidDebuffs:SetPoint(config.anchor[1], config.anchor[2], config.anchor[3], config.anchor[4])
 	RaidDebuffs:SetFrameLevel(Health:GetFrameLevel() + 10)
 	RaidDebuffs.icon = RaidDebuffs:CreateTexture(nil, "ARTWORK")
 	RaidDebuffs.icon:SetTexCoord(.1, .9, .1, .9)
@@ -245,7 +236,7 @@ end
 
 -- additional plugins
 -- Creates a panel for the unit name.
-local function createNamePanel(unitFrame)
+local function createNamePanel(unitFrame, config)
 	local Panel = CreateFrame("Frame", nil, unitFrame)
 	Panel:SetPoint("TOPLEFT", unitFrame.Power, "BOTTOMLEFT", 0, -1)
 	Panel:SetPoint("TOPRIGHT", unitFrame.Power, "BOTTOMRIGHT", 0, -1)
@@ -254,7 +245,7 @@ local function createNamePanel(unitFrame)
 	Panel.Backdrop:SetBorderColor(0, 0, 0, 0)
 
 	local Name = Panel:CreateFontString(nil, "OVERLAY")
-	Name:SetPoint("CENTER")
+	Name:SetPoint(config.nameAnchor)
 	Name:SetFontObject(Font)
 
 	unitFrame.Panel = Panel
@@ -268,19 +259,20 @@ local function createNamePanel(unitFrame)
 end
 
 -- Highlights the currently selected unit.
-local function createHighlight(unitFrame)
+local function createHighlight(unitFrame, config)
 	local Highlight = CreateFrame("Frame", nil, unitFrame, "BackdropTemplate")
-	Highlight:SetBackdrop({edgeFile = C.Medias.Glow, edgeSize = C.Raid.HighlightSize})
-	Highlight:SetOutside(unitFrame, C.Raid.HighlightSize, C.Raid.HighlightSize)
-	Highlight:SetBackdropBorderColor(unpack(C.Raid.HighlightColor))
+	Highlight:SetBackdrop({edgeFile = C.Medias.Glow, edgeSize = config.size})
+	Highlight:SetOutside(unitFrame, config.size, config.size)
+	Highlight:SetBackdropBorderColor(unpack(config.color))
 	Highlight:SetFrameLevel(0)
 	Highlight:Hide()
 
 	unitFrame.Highlight = Highlight
 end
 
--- Create new WidgetManager for Raid
-local RaidWidgets = UnitFrames.WidgetManager.new()
+-- Create new WidgetManager for Raid and expose for external edits.
+local RaidWidgets = UnitFrames.newWidgetManager()
+UnitFrames.RaidWidgets = RaidWidgets
 
 --[[ Raid style function. ]]
 function UnitFrames.Raid(self)
@@ -302,28 +294,34 @@ function UnitFrames.Raid(self)
 	self.Backdrop:SetBackdropColor(0, 0, 0)
 
 	-- oUF base elements
-	RaidWidgets:add("Health", createHealth)
-	RaidWidgets:add("Power", createPower)
-	RaidWidgets:add("RaidTargetIndicator", createRaidTargetIndicator)
-	RaidWidgets:add("ReadyCheckIndicator", createReadyCheckIndicator)
-	RaidWidgets:add("ResurrectIndicator", createResurrectIndicator)
-	RaidWidgets:add("Range", createRange)
+	RaidWidgets:add("Health", createHealth, { height = C.Raid.HeightSize - 1 - 3 - 1 -18,  -- border, power, border, namepanel
+		valueFont = HealthFont, valueAnchor = {"CENTER", 0, -6}, isRaid = true, Tag = C.Raid.HealthTag.Value })
+	RaidWidgets:add("Power", createPower, { isRaid = true})
+	RaidWidgets:add("RaidTargetIndicator", createRaidTargetIndicator, { size = C.UnitFrames.RaidIconSize, anchor = {"TOP", 0, C.UnitFrames.RaidIconSize / 2} })
+	RaidWidgets:add("ReadyCheckIndicator", createReadyCheckIndicator, { size = 12, anchor = {"CENTER"} })
+	RaidWidgets:add("ResurrectIndicator", createResurrectIndicator, { size = 24, anchor = {"CENTER"} })
+	RaidWidgets:add("Range", createRange, { outsideAlpha = C["Raid"].RangeAlpha })
 	if C.Raid.RaidBuffsStyle.Value == "Standard" then
-		RaidWidgets:add("Buffs", createBuffs)
+		RaidWidgets:add("Buffs", createBuffs, { filter = C.Raid.RaidBuffs.Value == "All" and "HELPFUL" or "HELPFUL|RAID",
+			onlyShowPlayer = C.Raid.RaidBuffs.Value == "Self", height = 16, width = 79, anchor = {"TOPLEFT"},
+			buffSize = 16, buffNum = 5, isRaid = true })
 	end
-	RaidWidgets:add("HealComm", createHealComm)
+	if C.UnitFrames.HealComm then
+		RaidWidgets:add("HealComm", createHealComm, { width = C.Raid.WidthSize })
+	end
 
 	-- oUF plugins
 	if C.Raid.RaidBuffsStyle.Value == "Aura Track" then
-		RaidWidgets:add("AuraTrack", createAuraTrack)
+		RaidWidgets:add("AuraTrack", createAuraTrack, { icons = C.Raid.AuraTrackIcons, texture = C.Raid.AuraTrackSpellTextures, thickness = C.Raid.AuraTrackThickness })
 	end
 	if C.Raid.DebuffWatch then
-		RaidWidgets:add("RaidDebuffs", createRaidDebuffs)
+		local height = C.Raid.HeightSize - 1 - 3 - 1 -18  -- border, power, border, namepanel
+		RaidWidgets:add("RaidDebuffs", createRaidDebuffs, { size = height >= 32 and height - 16 or height, anchor = {"CENTER"} })
 	end
 
 	-- additional plugins
-	RaidWidgets:add("NamePanel", createNamePanel)
-	RaidWidgets:add("Highlight", createHighlight)
+	RaidWidgets:add("NamePanel", createNamePanel, { nameAnchor = "CENTER" })
+	RaidWidgets:add("Highlight", createHighlight, { size = C.Raid.HighlightSize, color = C.Raid.HighlightColor })
 
 	RaidWidgets:createWidgets(self)
 

--- a/Tukui/Modules/UnitFrames/Groups/Raid.lua
+++ b/Tukui/Modules/UnitFrames/Groups/Raid.lua
@@ -9,8 +9,7 @@ local Font
 local HealthFont
 
 -- Make raid widgets available for external edits.
-UnitFrames.RaidWidgets = UnitFrames.newWidgetManager()
-local RaidWidgets = UnitFrames.RaidWidgets
+local RaidWidgets = UnitFrames.WidgetManager
 
 -- oUF base elements
 -- Configures oUF element Health.
@@ -46,7 +45,6 @@ local function createHealth(unitFrame)
 	unitFrame.Health.bg = Health.Background
 	unitFrame:Tag(Health.Value, C.Raid.HealthTag.Value)
 end
-RaidWidgets:addOrReplace("Health", createHealth)
 
 -- Configures oUF element Power.
 local function createPower(unitFrame)
@@ -71,7 +69,6 @@ local function createPower(unitFrame)
 	unitFrame.Power = Power
 	unitFrame.Power.bg = Power.Background
 end
-RaidWidgets:addOrReplace("Power", createPower)
 
 -- Configures oUF element RaidTargetIndicator.
 local function createRaidTargetIndicator(unitFrame)
@@ -82,7 +79,6 @@ local function createRaidTargetIndicator(unitFrame)
 
 	unitFrame.RaidTargetIndicator = RaidIcon
 end
-RaidWidgets:addOrReplace("RaidTargetIndicator", createRaidTargetIndicator)
 
 -- Configures oUF element ReadyCheckIndicator.
 local function createReadyCheckIndicator(unitFrame)
@@ -92,7 +88,6 @@ local function createReadyCheckIndicator(unitFrame)
 
 	unitFrame.ReadyCheckIndicator = ReadyCheck
 end
-RaidWidgets:addOrReplace("ReadyCheckIndicator", createReadyCheckIndicator)
 
 -- Configures oUF element ResurrectIndicator.
 local function createResurrectIndicator(unitFrame)
@@ -103,7 +98,6 @@ local function createResurrectIndicator(unitFrame)
 
 	unitFrame.ResurrectIndicator = ResurrectIndicator
 end
-RaidWidgets:addOrReplace("ResurrectIndicator", createResurrectIndicator)
 
 -- Configures oUF element Range.
 local function createRange(unitFrame)
@@ -114,7 +108,6 @@ local function createRange(unitFrame)
 
 	unitFrame.Range = Range
 end
-RaidWidgets:addOrReplace("Range", createRange)
 
 -- Configures oUF element Buffs (part of Auras).
 local function createBuffs(unitFrame)
@@ -141,9 +134,6 @@ local function createBuffs(unitFrame)
 	Buffs.PostUpdateButton = UnitFrames.DesaturateBuffs
 
 	unitFrame.Buffs = Buffs
-end
-if C.Raid.RaidBuffsStyle.Value == "Standard" then
-	RaidWidgets:addOrReplace("Buffs", createBuffs)
 end
 
 -- Configures oUF element HealthPrediction.
@@ -208,7 +198,6 @@ local function createHealComm(unitframe)
 		end
 	end
 end
-RaidWidgets:addOrReplace("HealComm", createHealComm)
 
 
 -- oUF Plugins
@@ -223,9 +212,6 @@ local function createAuraTrack(unitFrame)
 	AuraTrack.Font = C.Medias.Font
 
 	unitFrame.AuraTrack = AuraTrack
-end
-if C.Raid.RaidBuffsStyle.Value == "Aura Track" then
-	RaidWidgets:addOrReplace("AuraTrack", createAuraTrack)
 end
 
 -- Configures oUF_RaidDebuffs.
@@ -256,9 +242,6 @@ local function createRaidDebuffs(unitFrame)
 
 	unitFrame.RaidDebuffs = RaidDebuffs
 end
-if C.Raid.DebuffWatch then
-	RaidWidgets:addOrReplace("RaidDebuffs", createRaidDebuffs)
-end
 
 
 -- additional plugins
@@ -284,7 +267,6 @@ local function createNamePanel(unitFrame)
 		unitFrame:Tag(Name, "[Tukui:NameShort]")
 	end
 end
-RaidWidgets:addOrReplace("NamePanel", createNamePanel)
 
 -- Highlights the currently selected unit.
 local function createHighlight(unitFrame)
@@ -297,7 +279,6 @@ local function createHighlight(unitFrame)
 
 	unitFrame.Highlight = Highlight
 end
-RaidWidgets:addOrReplace("Highlight", createHighlight)
 
 
 --[[ Raid style function. ]]
@@ -318,6 +299,30 @@ function UnitFrames.Raid(self)
 	self.Backdrop:SetFrameLevel(self:GetFrameLevel())
 	self.Backdrop:SetBackdrop(UnitFrames.Backdrop)
 	self.Backdrop:SetBackdropColor(0, 0, 0)
+
+	-- oUF base elements
+	RaidWidgets:add("Health", createHealth)
+	RaidWidgets:add("Power", createPower)
+	RaidWidgets:add("RaidTargetIndicator", createRaidTargetIndicator)
+	RaidWidgets:add("ReadyCheckIndicator", createReadyCheckIndicator)
+	RaidWidgets:add("ResurrectIndicator", createResurrectIndicator)
+	RaidWidgets:add("Range", createRange)
+	if C.Raid.RaidBuffsStyle.Value == "Standard" then
+		RaidWidgets:add("Buffs", createBuffs)
+	end
+	RaidWidgets:add("HealComm", createHealComm)
+
+	-- oUF plugins
+	if C.Raid.RaidBuffsStyle.Value == "Aura Track" then
+		RaidWidgets:add("AuraTrack", createAuraTrack)
+	end
+	if C.Raid.DebuffWatch then
+		RaidWidgets:add("RaidDebuffs", createRaidDebuffs)
+	end
+
+	-- additional plugins
+	RaidWidgets:add("NamePanel", createNamePanel)
+	RaidWidgets:add("Highlight", createHighlight)
 
 	RaidWidgets:createWidgets(self)
 

--- a/Tukui/Modules/UnitFrames/WidgetManager.lua
+++ b/Tukui/Modules/UnitFrames/WidgetManager.lua
@@ -41,13 +41,15 @@ local function rebuildIndex(self, changedWidget)
 end
 
 
--- Returns the number of registered widgets.
+--[[ Returns the number of registered widgets. ]]
 function WidgetManager:getCount()
 	return Widgets[self].Count
 end
 
--- Add a new widget.
--- Returs the index it was added at or false if already existing.
+--[[ Add a new widget.
+
+	Returs the index it was added at or false if already existing.
+]]
 function WidgetManager:add(name, func, config)
 	-- name must not be a number, to not interfere with the index
 	if type(name) == "string" and not Widgets[self][name] then
@@ -63,15 +65,19 @@ function WidgetManager:add(name, func, config)
 	return false
 end
 
--- Returns the registered widget or nil.
--- Supports name or index to retrieve the widget.
+--[[ Returns the registered widget or nil.
+
+	Supports name or index to retrieve the widget.
+]]
 function WidgetManager:get(nameOrIndex)
 	local widget = Widgets[self][nameOrIndex]
 	return widget.index, widget.name, widget.func, widget.config
 end
 
--- Update an already registered widget.
--- Returns the index and name of the updated widget or nil if not found.
+--[[ Update an already registered widget.
+
+	Returns the index and name of the updated widget or nil if not found.
+]]
 function WidgetManager:update(nameOrIndex, func, config)
 	local widget = Widgets[self][nameOrIndex]
 	if widget then
@@ -81,8 +87,10 @@ function WidgetManager:update(nameOrIndex, func, config)
 	end
 end
 
--- Remove a registered widget.
--- Returns the removed widget or nil if not found.
+--[[ Remove a registered widget.
+
+	Returns the removed widget or nil if not found.
+]]
 function WidgetManager:remove(nameOrIndex)
 	local manager = Widgets[self]
 	local widget = manager[nameOrIndex]
@@ -95,8 +103,10 @@ function WidgetManager:remove(nameOrIndex)
 	end
 end
 
--- Insert a new widget at position "atIndex".
--- Returns the number of registered widgets or nil if failed.
+--[[ Insert a new widget at position "atIndex".
+
+	Returns the number of registered widgets or nil if failed.
+]]
 function WidgetManager:insert(atIndex, name, func, config)
 	local manager = Widgets[self]
 
@@ -110,7 +120,14 @@ function WidgetManager:insert(atIndex, name, func, config)
 	end
 end
 
--- Calls all registered widgets in order.
+--[[ Calls all registered widgets in order.
+
+	PreCreate:    Will be called before creating any widgets.
+	              This is the right time to add, insert, update and remove widgets/their config.
+
+	PostCreate:   Will be called after creating the widgets.
+	              Here the widgets are available and you can also edit properties that are not available in the config.
+]]
 function WidgetManager:createWidgets(unitFrame)
 	local manager = Widgets[self]
 
@@ -128,12 +145,9 @@ function WidgetManager:createWidgets(unitFrame)
 	end
 end
 
--- Create a new WidgetManager.
+--[[ Create a new WidgetManager. ]]
 function WidgetManager:new()
-	local manager = {
-		-- PreCreate,
-		-- PostCreate,
-	}
+	local manager = {}
 	Widgets[manager] = {
 		Count = 0,
 	}

--- a/Tukui/Modules/UnitFrames/WidgetManager.lua
+++ b/Tukui/Modules/UnitFrames/WidgetManager.lua
@@ -110,22 +110,34 @@ function WidgetManager:insert(atIndex, name, func, config)
 	end
 end
 
---Calls all registered widgets in order.
+-- Calls all registered widgets in order.
 function WidgetManager:createWidgets(unitFrame)
 	local manager = Widgets[self]
+
+	if self.PreCreate then
+		self.PreCreate(unitFrame)
+	end
 
 	for i = 1, manager.Count do
 		local widget = manager[i]
 		widget.func(unitFrame, widget.config)
 	end
+
+	if self.PostCreate then
+		self.PostCreate(unitFrame)
+	end
 end
 
+-- Create a new WidgetManager.
 function WidgetManager:new()
-	local manager = {}
+	local manager = {
+		-- PreCreate,
+		-- PostCreate,
+	}
 	Widgets[manager] = {
-		Count = 0
+		Count = 0,
 	}
 	return setmetatable(manager, { __index = WidgetManager })
 end
 
-UnitFrames.WidgetManager = WidgetManager
+UnitFrames.newWidgetManager = WidgetManager.new


### PR DESCRIPTION
WidgetManager now supports the storage of accompanying config and Pre and PostCreate hooks were added (and tested) for external edits. 
Raid element functions further refined with the config. The general Tukui style is still within the elements, the differentiating config at the create calls. 

Next step would be to move element functions somewhere more centrally and reuse also for other unit frames to reduce code duplication.