### PR TITLE
Fix lua error when loading into 11.0.5 patch

### DIFF
--- a/Tukui/Modules/DataTexts/Elements/Guild.lua
+++ b/Tukui/Modules/DataTexts/Elements/Guild.lua
@@ -16,7 +16,7 @@ local EnglishClass = function(class)
 			return i
 		end
 	end
-	
+
 	-- Females
 	for i, j in pairs(LOCALIZED_CLASS_NAMES_FEMALE) do
 		if class == j then
@@ -59,7 +59,7 @@ local OnMouseDown = function(self, button)
 end
 
 local OnEnter = function(self)
-	local NumTotalMembers, NumOnlineMaxLevelMembers, NumOnlineMembers = GetNumGuildMembers()
+	local NumTotalMembers, NumOnlineMembers, NumOnlineAndMobileMembers = GetNumGuildMembers()
 
 	if not IsInGuild() or NumOnlineMembers <= 0 then
 		return
@@ -135,8 +135,9 @@ local Update = function(self)
 
 		return
 	end
+	local NumTotalMembers, NumOnlineMembers, NumOnlineAndMobileMembers = GetNumGuildMembers()
 
-	self.Text:SetFormattedText("%s %s", DataText.NameColor .. GUILD .. "|r", DataText.ValueColor .. select(3, GetNumGuildMembers()) .. "|r")
+	self.Text:SetFormattedText("%s %s", DataText.NameColor .. GUILD .. "|r", DataText.ValueColor .. NumOnlineMembers .. "|r")
 end
 
 local Enable = function(self)


### PR DESCRIPTION
GetNumGuildMembers 3rd return value is currently always nil so switched to the 2nd return value. This should also be fitting for the use case:
numTotalGuildMembers, numOnlineGuildMembers, numOnlineAndMobileMembers = GetNumGuildMembers()

So after this change it wouldn't list people that are on mobile, but I think it never really did?