### PR TITLE
BagsRetail sorting and looting

### DIFF
--- a/Tukui/Modules/Inventory/BagsRetail.lua
+++ b/Tukui/Modules/Inventory/BagsRetail.lua
@@ -201,13 +201,12 @@ function Bags:Enable()
 	end
 
 	SetCVar("combinedBags", 1)
+	C_Container.SetInsertItemsLeftToRight(false)
 
 	if C.Bags.SortToBottom then
 		C_Container.SetSortBagsRightToLeft(false)
-		C_Container.SetInsertItemsLeftToRight(true)
 	else
 		C_Container.SetSortBagsRightToLeft(true)
-		C_Container.SetInsertItemsLeftToRight(false)
 	end
 
 	-- Create the AIO container on load

--- a/Tukui/Modules/Inventory/BagsRetail.lua
+++ b/Tukui/Modules/Inventory/BagsRetail.lua
@@ -10,7 +10,7 @@ function Bags:SkinButton(Button)
 	if not Button then
 		return
 	end
-	
+
 	Button:StripTextures()
 	Button:CreateBackdrop()
 	Button.IconBorder:SetAlpha(0)
@@ -21,11 +21,11 @@ end
 function Bags:SkinButtons()
 	local Bag = ContainerFrameCombinedBags
 	local Reagent = ContainerFrame6
-	
+
 	for i, Button in Bag:EnumerateValidItems() do
 		Bags:SkinButton(Button)
 	end
-	
+
 	for i, Button in Reagent:EnumerateValidItems() do
 		Bags:SkinButton(Button)
 	end
@@ -50,7 +50,7 @@ function Bags:UpdateItems()
 		local QuestID = QuestInfo.questID
 		local IsActive = QuestInfo.isActive
 		local R, G, B
-		
+
 		if Button.Backdrop then
 			if Quality then
 				R, G, B = C_Item.GetItemQualityColor(Quality)
@@ -60,7 +60,7 @@ function Bags:UpdateItems()
 				Button.Backdrop:SetBorderColor(unpack(C.General.BorderColor))
 			end
 		end
-		
+
 		-- Quest Items
 		if C.Bags.IdentifyQuestItems and IsQuestItem then
 			if not Button.Quest then
@@ -93,7 +93,7 @@ function Bags:UpdateItems()
 				Button.Quest:Hide()
 			end
 		end
-		
+
 		-- Items Level
 		if C.Bags.ItemLevel then
 			if ItemLink then
@@ -149,32 +149,32 @@ function Bags:SkinContainer()
 	NineSlice:SetTemplate()
 	NineSlice:SetFrameLevel(0)
 	NineSlice:CreateShadow()
-	
+
 	CloseButton:SkinCloseButton()
-	
+
 	Portrait:Kill()
-	
+
 	TokensBorder:Kill()
-	
+
 	MoneyBorder:Kill()
-	
+
 	SearchBox:StripTextures()
 	SearchBox:SkinEditBox()
-	
+
 	-- Reagent Bag
 	if ContainerFrame6 then
 		local ReagentContainer = ContainerFrame6
 		local ReagentNineSlice = ReagentContainer.NineSlice
 		local ReagentCloseButton = ReagentContainer.CloseButton
 		local ReagentPortrait = ContainerFrame6Portrait
-		
+
 		ReagentNineSlice:StripTextures()
 		ReagentNineSlice:SetTemplate()
 		ReagentNineSlice:SetFrameLevel(0)
 		ReagentNineSlice:CreateShadow()
-		
+
 		ReagentCloseButton:SkinCloseButton()
-		
+
 		ReagentPortrait:Kill()
 	end
 end
@@ -201,7 +201,7 @@ function Bags:Enable()
 	end
 
 	SetCVar("combinedBags", 1)
-	
+
 	if C.Bags.SortToBottom then
 		C_Container.SetSortBagsRightToLeft(false)
 		C_Container.SetInsertItemsLeftToRight(true)
@@ -209,18 +209,18 @@ function Bags:Enable()
 		C_Container.SetSortBagsRightToLeft(true)
 		C_Container.SetInsertItemsLeftToRight(false)
 	end
-	
+
 	-- Create the AIO container on load
 	ToggleAllBags()
 	ToggleAllBags()
-	
+
 	-- Start doing shit
 	self:AddHooks()
 	self:SkinContainer()
 	self:SkinButtons()
-	
+
 	Movers:RegisterFrame(ContainerFrameCombinedBags, "Bags")
-	
+
 	T.Print("The bags module is currently under development, please be patient")
 end
 


### PR DESCRIPTION
Sorting option in config only influences sorting now. 

New items always go to the start of a bag, so really starting at the bottom is not possible. The current default makes it rather weird with items going close to the bottom but still somewhere in nowhere. 