### PR TITLE
Fix: ADDON_ACTION_BLOCKED taint in dungeons (ElvUI v13.94-13.97 solution)

### DIFF
--- a/Tukui/Modules/Auras/Templates.xml
+++ b/Tukui/Modules/Auras/Templates.xml
@@ -1,9 +1,9 @@
 <Ui xmlns="http://www.blizzard.com/wow/ui/">
-	<Button name="AurasTemplate" inherits="SecureActionButtonTemplate" virtual="true">
+	<Button name="AurasTemplate" inherits="SecureActionButtonTemplate" virtual="true" registerForClicks="RightButtonUp, RightButtonDown">
 		<Size x="30" y="30"/>
 
 		<Attributes>
-			<Attribute name="type" value="cancelaura"/>
+			<Attribute name="type2" value="cancelaura"/>
 		</Attributes>
 
 		<Scripts>
@@ -12,8 +12,9 @@
 				local Auras = T["Auras"]
 
 				Auras.Skin(self)
-
-				self:RegisterForClicks("RightButtonUp")
+				
+				-- Don't call RegisterForClicks here - it's set in the XML template
+				-- This was causing taint when called during combat
 			</OnLoad>
 
 			<OnEnter>


### PR DESCRIPTION
## Summary
Fixes the ADDON_ACTION_BLOCKED taint error that occurs specifically in dungeons/raids by implementing the same solution ElvUI used between versions 13.94-13.97.

## Problem
After Blizzard's fix for the WeakAura/Hekili exploit, calling `RegisterForClicks()` from Lua code during OnLoad spreads taint to secure frames. This causes errors in dungeons when UNIT_AURA events fire:
```
[ADDON_ACTION_BLOCKED] AddOn 'Tukui' tried to call the protected function 'UNKNOWN()'
[Blizzard_FrameXML/SecureGroupHeaders.lua]:693
```

## Solution
Move `registerForClicks` from Lua OnLoad to XML template attribute, where it's processed in the secure environment before any addon code runs.

## Changes
- Move `registerForClicks` from `self:RegisterForClicks()` to XML attribute
- Add `RightButtonDown` alongside `RightButtonUp` for proper click handling  
- Change `type` to `type2` for right-click cancelaura functionality

## Testing
- ✅ Tested in various dungeons/raids
- ✅ No ADDON_ACTION_BLOCKED errors
- ✅ Right-click buff canceling works correctly

## References
- Based on ElvUI's fix between v13.94-13.97
- ElvUI changelog: "SecureAuraHeader_Update taint errors resolved"
- Related to Blizzard's post-exploit security tightening

This is a minimal, targeted fix that addresses only the core taint issue.