### PR TITLE
Loads the new spec and talent UI on click.

### DIFF
--- a/Tukui/Modules/DataTexts/Elements/Talents.lua
+++ b/Tukui/Modules/DataTexts/Elements/Talents.lua
@@ -16,9 +16,9 @@ local Update = function(self)
 	CurrentCharSpecName = CurrentSpec and select(2, GetSpecializationInfo(CurrentSpec))
 
 	local lastSelected = PlayerUtil.GetCurrentSpecID() and C_ClassTalents.GetLastSelectedSavedConfigID(PlayerUtil.GetCurrentSpecID())
-	local selectionID = PlayerSpellsFrame and PlayerSpellsFrame.TalentsFrame and PlayerSpellsFrame.TalentsFrame.LoadoutDropDown and
-		PlayerSpellsFrame.TalentsFrame.LoadoutDropDown.GetSelectionID and
-		PlayerSpellsFrame.TalentsFrame.LoadoutDropDown:GetSelectionID()
+	local selectionID = PlayerSpellsFrame and PlayerSpellsFrame.TalentsFrame and PlayerSpellsFrame.TalentsFrame.LoadSystem and
+		PlayerSpellsFrame.TalentsFrame.LoadSystem.GetSelectionID and
+		PlayerSpellsFrame.TalentsFrame.LoadSystem:GetSelectionID()
 
 	-- https://warcraft.wiki.gg/wiki/Dragonflight_Talent_System
 	-- the priority in authoritativeness is [default UI's dropdown] > [API] > ['ActiveConfigID'] > nil
@@ -73,6 +73,7 @@ local Enable = function(self)
 	self:RegisterEvent("PLAYER_LOOT_SPEC_UPDATED")
 	self:RegisterEvent("PLAYER_ENTERING_WORLD")
 	self:RegisterEvent("CONFIRM_TALENT_WIPE")
+	self:RegisterEvent("TRAIT_CONFIG_UPDATED")
 
 	self:SetScript("OnEvent", Update)
 	self:SetScript("OnEnter", OnEnter)

--- a/Tukui/Modules/DataTexts/Elements/Talents.lua
+++ b/Tukui/Modules/DataTexts/Elements/Talents.lua
@@ -1,6 +1,7 @@
 local T, C, L = unpack((select(2, ...)))
 
 --[[ This datatext is from: SanUI, by Pyrates ]] --
+local GameTooltip = _G.GameTooltip
 
 local DataText = T["DataTexts"]
 
@@ -8,30 +9,26 @@ local CurrentLootSpecName
 local CurrentCharSpecName
 
 local Update = function(self)
-	local CurrentLootSpec = GetLootSpecialization()
 	local CurrentSpec = GetSpecialization()
+	local CurrentLootSpec = GetLootSpecialization()
 
-	CurrentLootSpecName = CurrentLootSpec and select(2, GetSpecializationInfoByID(CurrentLootSpec))
+	if CurrentSpec then
+		CurrentCharSpecName = select(2, GetSpecializationInfo(CurrentSpec))
+		CurrentLootSpecName = CurrentLootSpec == 0 and CurrentCharSpecName or select(2, GetSpecializationInfoByID(CurrentLootSpec))
 
-	CurrentCharSpecName = CurrentSpec and select(2, GetSpecializationInfo(CurrentSpec))
-
-	if (CurrentLootSpec ~=0 and CurrentLootSpecName == nil) or CurrentCharSpecName == nil then
+		if CurrentCharSpecName and CurrentLootSpecName then
+			self.Text:SetText("S " .. CurrentCharSpecName .. " - L " .. CurrentLootSpecName)
+		else
+			self.Text:SetText("+--+")
+		end
+	else
 		self.Text:SetText("+--+")
-
-		return
 	end
-
-	if CurrentLootSpec == 0 then
-		CurrentLootSpecName = CurrentCharSpecName
-	end
-
-	self.Text:SetText(CurrentCharSpecName)
 end
 
 local OnLeave = function()
 	GameTooltip:Hide()
 end
-
 
 local OnEnter = function(self)
 	self:Update()
@@ -45,21 +42,19 @@ local OnEnter = function(self)
 	GameTooltip:Show()
 end
 
-local OnMouseDown = function()
+local OnMouseDown = function(self, button)
 	if InCombatLockdown() then
 		T.Print(ERR_NOT_IN_COMBAT)
 
 		return
 	end
 
-	if not PlayerTalentFrame then
-		LoadAddOn("Blizzard_TalentUI")
-	end
-
-	if not PlayerTalentFrame:IsShown() then
-		ShowUIPanel(PlayerTalentFrame)
+	if button == "LeftButton" then
+		-- Opens Specialization pane
+		PlayerSpellsUtil.TogglePlayerSpellsFrame(1)
 	else
-		HideUIPanel(PlayerTalentFrame)
+		-- Opens Talents pane
+		PlayerSpellsUtil.TogglePlayerSpellsFrame(2)
 	end
 end
 

--- a/Tukui/Modules/DataTexts/Elements/Talents.lua
+++ b/Tukui/Modules/DataTexts/Elements/Talents.lua
@@ -9,18 +9,25 @@ local CurrentLootSpecName
 local CurrentCharSpecName
 
 local Update = function(self)
-	local CurrentSpec = GetSpecialization()
 	local CurrentLootSpec = GetLootSpecialization()
+	local CurrentSpec = GetSpecialization()
 
-	if CurrentSpec then
-		CurrentCharSpecName = select(2, GetSpecializationInfo(CurrentSpec))
-		CurrentLootSpecName = CurrentLootSpec == 0 and CurrentCharSpecName or select(2, GetSpecializationInfoByID(CurrentLootSpec))
+	CurrentLootSpecName = CurrentLootSpec and select(2, GetSpecializationInfoByID(CurrentLootSpec))
+	CurrentCharSpecName = CurrentSpec and select(2, GetSpecializationInfo(CurrentSpec))
 
-		if CurrentCharSpecName and CurrentLootSpecName then
-			self.Text:SetText("S " .. CurrentCharSpecName .. " - L " .. CurrentLootSpecName)
-		else
-			self.Text:SetText("+--+")
-		end
+	local lastSelected = PlayerUtil.GetCurrentSpecID() and C_ClassTalents.GetLastSelectedSavedConfigID(PlayerUtil.GetCurrentSpecID())
+	local selectionID = PlayerSpellsFrame and PlayerSpellsFrame.TalentsFrame and PlayerSpellsFrame.TalentsFrame.LoadoutDropDown and
+		PlayerSpellsFrame.TalentsFrame.LoadoutDropDown.GetSelectionID and
+		PlayerSpellsFrame.TalentsFrame.LoadoutDropDown:GetSelectionID()
+
+	-- https://warcraft.wiki.gg/wiki/Dragonflight_Talent_System
+	-- the priority in authoritativeness is [default UI's dropdown] > [API] > ['ActiveConfigID'] > nil
+	-- nil happens when you don't have any spec selected, e.g. on a freshly created character
+	local activeConfigID = selectionID or lastSelected or C_ClassTalents.GetActiveConfigID() or nil
+
+	if activeConfigID then
+		local configInfo = C_Traits.GetConfigInfo(activeConfigID)
+		self.Text:SetText(configInfo["name"])
 	else
 		self.Text:SetText("+--+")
 	end


### PR DESCRIPTION
Fixes the error currently popping when clicking on the talent datatext. Instead loads the new Specialization and Talent UI.
LeftButton -> Specialization pane
Any other button -> Talents pane
(same window, different tab)