### PR TITLE
Remove default background texture from StaticPopups (#242)

### DIFF
--- a/Tukui/Modules/Miscellaneous/StaticPopups.lua
+++ b/Tukui/Modules/Miscellaneous/StaticPopups.lua
@@ -16,6 +16,7 @@ function StaticPopups:Skin()
 	_G[Name]:StripTextures()
 	_G[Name]:CreateBackdrop("Transparent")
 	_G[Name]:CreateShadow()
+	_G[Name].BG:DisableDrawLayer("BACKGROUND") -- remove default background texture
 	_G[Name.."Button1"]:StripTextures()
 	_G[Name.."Button2"]:StripTextures()
 	_G[Name.."Button3"]:StripTextures()


### PR DESCRIPTION
PR #243 fixed lua errors, but now the blizzard default background shows up in the popups. This PR fixes this by removing them again.